### PR TITLE
Fix warnings (potentially errors) when using Initialize_Scalars

### DIFF
--- a/src/core/aws-net-websocket-protocol-draft76.adb
+++ b/src/core/aws-net-websocket-protocol-draft76.adb
@@ -182,6 +182,7 @@ package body AWS.Net.WebSocket.Protocol.Draft76 is
       V1 : constant Interfaces.Unsigned_32 := WS_Key_Value (K1);
       B1 : Stream_Element_Array (1 .. 4);
       for B1'Address use V1'Address;
+      pragma Import (Ada, B1);  --  disable default initialization
 
       --  Key 2
 
@@ -190,6 +191,7 @@ package body AWS.Net.WebSocket.Protocol.Draft76 is
       V2 : constant Interfaces.Unsigned_32 := WS_Key_Value (K2);
       B2 : Stream_Element_Array (1 .. 4);
       for B2'Address use V2'Address;
+      pragma Import (Ada, B2);  --  disable default initialization
 
       --  Body
 
@@ -200,6 +202,7 @@ package body AWS.Net.WebSocket.Protocol.Draft76 is
       D  : MD5.Message_Digest;
       S  : Stream_Element_Array (1 .. D'Length);
       for S'Address use D'Address;
+      pragma Import (Ada, S);  --  disable default initialization
 
    begin
       if B'Length /= 8 then

--- a/src/core/aws-net-websocket-protocol-rfc6455.adb
+++ b/src/core/aws-net-websocket-protocol-rfc6455.adb
@@ -238,6 +238,7 @@ package body AWS.Net.WebSocket.Protocol.RFC6455 is
       D_Header : Stream_Element_Array (1 .. 2) := (0, 0);
       Header   : Frame_Header;
       for Header'Address use D_Header'Address;
+      pragma Import (Ada, Header);  --  Disable default initialization
 
       D_16     : Stream_Element_Array (1 .. 2);
       for D_16'Alignment use Interfaces.Unsigned_16'Alignment;
@@ -577,6 +578,7 @@ package body AWS.Net.WebSocket.Protocol.RFC6455 is
       D_Header : Stream_Element_Array (1 .. 2) := (0, 0);
       Header   : Frame_Header;
       for Header'Address use D_Header'Address;
+      pragma Import (Ada, Header);  --  Disable default initialization
 
       D_16     : Stream_Element_Array (1 .. 2);
       for D_16'Alignment use Interfaces.Unsigned_16'Alignment;


### PR DESCRIPTION
When compiling the code with pragma Initialize_Scalars, we get a number of compiler warnings like:

   Building ........................................................... (400/504)
      aws-net-websocket-protocol-draft76.adb:184:11: warning: default initialization of "B1" may modify "V1"
      aws-net-websocket-protocol-draft76.adb:184:11: warning: use pragma Import for "B1" to suppress initialization (RM B.1(24))
      aws-net-websocket-protocol-draft76.adb:192:11: warning: default initialization of "B2" may modify "V2"
      aws-net-websocket-protocol-draft76.adb:192:11: warning: use pragma Import for "B2" to suppress initialization (RM B.1(24))
      aws-net-websocket-protocol-draft76.adb:202:11: warning: default initialization of "S" may modify "D"
      aws-net-websocket-protocol-draft76.adb:202:11: warning: use pragma Import for "S" to suppress initialization (RM B.1(24))
   Building ........................................................... (402/504)
      aws-net-websocket-protocol-rfc6455.adb:240:11: warning: default initialization of "Header" may modify "D_Header"
      aws-net-websocket-protocol-rfc6455.adb:240:11: warning: use pragma Import for "Header" to suppress initialization (RM B.1(24))
      aws-net-websocket-protocol-rfc6455.adb:579:11: warning: default initialization of "Header" may modify "D_Header"
      aws-net-websocket-protocol-rfc6455.adb:579:11: warning: use pragma Import for "Header" to suppress initialization (RM B.1(24))


which are valid and in fact might result in wrong behavior at execution