### PR TITLE
Support for client-side logging of SOAP calls

### DIFF
--- a/src/soap/soap-client-callback.ads
+++ b/src/soap/soap-client-callback.ads
@@ -6,13 +6,11 @@ package SOAP.Client.Callback is
    --  Callback routine types
    type Pre_Call_CB is not null access
       procedure (Connection : AWS.Client.HTTP_Connection;
-                 SOAPAction : String;
                  Request    : SOAP.Message.Payload.Object;
                  Schema     : SOAP.WSDL.Schema.Definition);
 
    type Post_Call_CB is not null access
       procedure (Connection : AWS.Client.HTTP_Connection;
-                 SOAPAction : String;
                  Request    : SOAP.Message.Payload.Object;
                  Response   : SOAP.Message.Response.Object'Class;
                  Schema     : SOAP.WSDL.Schema.Definition);
@@ -20,13 +18,11 @@ package SOAP.Client.Callback is
    --  Default callback routines
    procedure Null_Pre_Call_Callback
       (Connection : AWS.Client.HTTP_Connection;
-       SOAPAction : String;
        Request    : SOAP.Message.Payload.Object;
        Schema     : SOAP.WSDL.Schema.Definition) is null;
 
    procedure Null_Post_Call_Callback
       (Connection : AWS.Client.HTTP_Connection;
-       SOAPAction : String;
        Request    : SOAP.Message.Payload.Object;
        Response   : SOAP.Message.Response.Object'Class;
        Schema     : SOAP.WSDL.Schema.Definition) is null;

--- a/src/soap/soap-client-callback.ads
+++ b/src/soap/soap-client-callback.ads
@@ -1,0 +1,34 @@
+with SOAP.Message.Payload;
+with SOAP.Message.Response;
+
+package SOAP.Client.Callback is
+
+   --  Callback routine types
+   type Pre_Call_CB is not null access
+      procedure (Connection : AWS.Client.HTTP_Connection;
+                 SOAPAction : String;
+                 Request    : SOAP.Message.Payload.Object;
+                 Schema     : SOAP.WSDL.Schema.Definition);
+
+   type Post_Call_CB is not null access
+      procedure (Connection : AWS.Client.HTTP_Connection;
+                 SOAPAction : String;
+                 Request    : SOAP.Message.Payload.Object;
+                 Response   : SOAP.Message.Response.Object'Class;
+                 Schema     : SOAP.WSDL.Schema.Definition);
+
+   --  Default callback routines
+   procedure Null_Pre_Call_Callback
+      (Connection : AWS.Client.HTTP_Connection;
+       SOAPAction : String;
+       Request    : SOAP.Message.Payload.Object;
+       Schema     : SOAP.WSDL.Schema.Definition) is null;
+
+   procedure Null_Post_Call_Callback
+      (Connection : AWS.Client.HTTP_Connection;
+       SOAPAction : String;
+       Request    : SOAP.Message.Payload.Object;
+       Response   : SOAP.Message.Response.Object'Class;
+       Schema     : SOAP.WSDL.Schema.Definition) is null;
+
+end SOAP.Client.Callback;

--- a/src/soap/soap-utils.adb
+++ b/src/soap/soap-utils.adb
@@ -449,24 +449,15 @@ package body SOAP.Utils is
                TZ := -TZ;
             end if;
          end if;
-
-         T := Time_Of (Year      => Year_Number'Value (TI (Year_Range)),
-                       Month     => Month_Number'Value (TI (Month_Range)),
-                       Day       => Day_Number'Value (TI (Day_Range)),
-                       Hour      => Hour_Number'Value (TI (Hour_Range)),
-                       Minute    => Minute_Number'Value (TI (Minute_Range)),
-                       Second    => Second_Number'Value (TI (Second_Range)),
-                       Time_Zone => TZ);
-      else
-        -- No time zone specified, assume local time
-        T := Ada.Calendar.Time_Of (Year    => Year_Number'Value (TI (Year_Range)),
-                                   Month   => Month_Number'Value (TI (Month_Range)),
-                                   Day     => Day_Number'Value (TI (Day_Range)),
-                                   Seconds => Duration
-                                      (Natural'Value (TI (Hour_Range)) * 3600
-                                          + Natural'Value (TI (Minute_Range)) * 60
-                                          + Natural'Value (TI (Second_Range))));
       end if;
+
+      T := Time_Of (Year      => Year_Number'Value (TI (Year_Range)),
+                    Month     => Month_Number'Value (TI (Month_Range)),
+                    Day       => Day_Number'Value (TI (Day_Range)),
+                    Hour      => Hour_Number'Value (TI (Hour_Range)),
+                    Minute    => Minute_Number'Value (TI (Minute_Range)),
+                    Second    => Second_Number'Value (TI (Second_Range)),
+                    Time_Zone => TZ);
 
       return Types.T (T, Name, Type_Name => Type_Name);
    end Time_Instant;

--- a/src/soap/soap-utils.adb
+++ b/src/soap/soap-utils.adb
@@ -449,15 +449,24 @@ package body SOAP.Utils is
                TZ := -TZ;
             end if;
          end if;
-      end if;
 
-      T := Time_Of (Year      => Year_Number'Value (TI (Year_Range)),
-                    Month     => Month_Number'Value (TI (Month_Range)),
-                    Day       => Day_Number'Value (TI (Day_Range)),
-                    Hour      => Hour_Number'Value (TI (Hour_Range)),
-                    Minute    => Minute_Number'Value (TI (Minute_Range)),
-                    Second    => Second_Number'Value (TI (Second_Range)),
-                    Time_Zone => TZ);
+         T := Time_Of (Year      => Year_Number'Value (TI (Year_Range)),
+                       Month     => Month_Number'Value (TI (Month_Range)),
+                       Day       => Day_Number'Value (TI (Day_Range)),
+                       Hour      => Hour_Number'Value (TI (Hour_Range)),
+                       Minute    => Minute_Number'Value (TI (Minute_Range)),
+                       Second    => Second_Number'Value (TI (Second_Range)),
+                       Time_Zone => TZ);
+      else
+        -- No time zone specified, assume local time
+        T := Ada.Calendar.Time_Of (Year    => Year_Number'Value (TI (Year_Range)),
+                                   Month   => Month_Number'Value (TI (Month_Range)),
+                                   Day     => Day_Number'Value (TI (Day_Range)),
+                                   Seconds => Duration
+                                      (Natural'Value (TI (Hour_Range)) * 3600
+                                          + Natural'Value (TI (Minute_Range)) * 60
+                                          + Natural'Value (TI (Second_Range))));
+      end if;
 
       return Types.T (T, Name, Type_Name => Type_Name);
    end Time_Instant;

--- a/tools/wsdl2aws-generator-stub.adb
+++ b/tools/wsdl2aws-generator-stub.adb
@@ -453,9 +453,7 @@ package body Stub is
       if O.Gen_CB then
          Text_IO.Put_Line
             (Stub_Adb,
-             "      Pre_Call_Callback (Connection, " &
-                """" & To_String (O.Prefix) & Proc & """, " &
-                "Payload, Schema);");
+             "      Pre_Call_Callback (Connection, Payload, Schema);");
       end if;
 
       Text_IO.New_Line (Stub_Adb);
@@ -499,9 +497,7 @@ package body Stub is
       if O.Gen_CB then
          Text_IO.Put_Line
             (Stub_Adb,
-             "      Post_Call_Callback (Connection, " &
-                """" & To_String (O.Prefix) & Proc & """, " &
-                "Payload, Response, Schema);");
+             "      Post_Call_Callback (Connection, Payload, Response, Schema);");
       end if;
 
       Text_IO.Put_Line

--- a/tools/wsdl2aws-generator-stub.adb
+++ b/tools/wsdl2aws-generator-stub.adb
@@ -450,7 +450,7 @@ package body Stub is
             "                & SOAP.Message.XML.Image (Payload, Schema));");
       end if;
 
-      if O.Gen_CB then
+      if O.Traces then
          Text_IO.Put_Line
             (Stub_Adb,
              "      Pre_Call_Callback (Connection, Payload, Schema);");
@@ -458,6 +458,7 @@ package body Stub is
 
       Text_IO.New_Line (Stub_Adb);
       Text_IO.Put_Line (Stub_Adb, "      declare");
+
       Text_IO.Put_Line
         (Stub_Adb,
          "         Response : constant SOAP.Message.Response.Object'Class");
@@ -494,10 +495,11 @@ package body Stub is
          Text_IO.New_Line (Stub_Adb);
       end if;
 
-      if O.Gen_CB then
+      if O.Traces then
          Text_IO.Put_Line
             (Stub_Adb,
-             "      Post_Call_Callback (Connection, Payload, Response, Schema);");
+             "         Post_Call_Callback (Connection," &
+             " Payload, Response, Schema);");
       end if;
 
       Text_IO.Put_Line
@@ -714,6 +716,11 @@ package body Stub is
          end loop;
       end;
 
+      if O.Traces then
+         Text_IO.Put
+           (Stub_Adb, ", Pre_Call_Callback, Post_Call_Callback");
+      end if;
+
       Text_IO.Put_Line (Stub_Adb, ");");
 
       if Output /= null then
@@ -756,7 +763,7 @@ package body Stub is
       Text_IO.New_Line (Stub_Ads);
       With_Unit (Stub_Ads, "Ada.Calendar", Elab => Off);
       Text_IO.New_Line (Stub_Ads);
-      if O.Gen_CB then
+      if O.Traces then
          With_Unit (Stub_Ads, "SOAP.Client.Callback", Elab => Off);
       end if;
       With_Unit (Stub_Ads, "SOAP.Types", Elab => Children);
@@ -771,7 +778,7 @@ package body Stub is
       Text_IO.New_Line (Stub_Ads);
       Text_IO.Put_Line (Stub_Ads, "   use " & U_Name & ".Types;");
 
-      if O.Gen_CB then
+      if O.Traces then
          Text_IO.Put_Line (Stub_Ads, "   use SOAP.Client.Callback;");
       end if;
 

--- a/tools/wsdl2aws-generator-stub.adb
+++ b/tools/wsdl2aws-generator-stub.adb
@@ -450,6 +450,14 @@ package body Stub is
             "                & SOAP.Message.XML.Image (Payload, Schema));");
       end if;
 
+      if O.Gen_CB then
+         Text_IO.Put_Line
+            (Stub_Adb,
+             "      Pre_Call_Callback (Connection, " &
+                """" & To_String (O.Prefix) & Proc & """, " &
+                "Payload, Schema);");
+      end if;
+
       Text_IO.New_Line (Stub_Adb);
       Text_IO.Put_Line (Stub_Adb, "      declare");
       Text_IO.Put_Line
@@ -486,6 +494,14 @@ package body Stub is
             "                   "
             & "& SOAP.Message.XML.Image (Response, Schema));");
          Text_IO.New_Line (Stub_Adb);
+      end if;
+
+      if O.Gen_CB then
+         Text_IO.Put_Line
+            (Stub_Adb,
+             "      Post_Call_Callback (Connection, " &
+                """" & To_String (O.Prefix) & Proc & """, " &
+                "Payload, Response, Schema);");
       end if;
 
       Text_IO.Put_Line
@@ -744,6 +760,9 @@ package body Stub is
       Text_IO.New_Line (Stub_Ads);
       With_Unit (Stub_Ads, "Ada.Calendar", Elab => Off);
       Text_IO.New_Line (Stub_Ads);
+      if O.Gen_CB then
+         With_Unit (Stub_Ads, "SOAP.Client.Callback", Elab => Off);
+      end if;
       With_Unit (Stub_Ads, "SOAP.Types", Elab => Children);
       Text_IO.New_Line (Stub_Ads);
       With_Unit (Stub_Ads, U_Name & ".Types", Elab => Off);
@@ -755,6 +774,10 @@ package body Stub is
       Text_IO.Put_Line (Stub_Ads, "package " & U_Name & ".Client is");
       Text_IO.New_Line (Stub_Ads);
       Text_IO.Put_Line (Stub_Ads, "   use " & U_Name & ".Types;");
+
+      if O.Gen_CB then
+         Text_IO.Put_Line (Stub_Ads, "   use SOAP.Client.Callback;");
+      end if;
 
       Text_IO.New_Line (Stub_Ads);
       Text_IO.Put_Line
@@ -789,6 +812,7 @@ package body Stub is
       Text_IO.Put_Line (Stub_Adb, "   use type SOAP.Parameters.List;");
       Text_IO.New_Line (Stub_Adb);
       Text_IO.Put_Line (Stub_Adb, "   pragma Style_Checks (Off);");
+      Text_IO.New_Line (Stub_Adb);
    end Start_Service;
 
 end Stub;

--- a/tools/wsdl2aws-generator.adb
+++ b/tools/wsdl2aws-generator.adb
@@ -927,7 +927,7 @@ package body WSDL2AWS.Generator is
             Input_Parameters;
          end if;
 
-         if O.Gen_CB then
+         if O.Traces then
             Text_IO.Put_Line (File, ";");
             Put_Indent;
             Text_IO.Put_Line
@@ -983,7 +983,7 @@ package body WSDL2AWS.Generator is
               (File, " : AWS.Client.Timeouts_Values := "
                   & To_String (O.Unit) & ".Timeouts");
 
-            if O.Gen_CB then
+            if O.Traces then
                Text_IO.Put_Line (File, ";");
                Put_Indent;
                Text_IO.Put_Line
@@ -4386,6 +4386,15 @@ package body WSDL2AWS.Generator is
       return Strings.Fixed.Translate
         (Filename, Strings.Maps.To_Mapping ("-", "."));
    end To_Unit_Name;
+
+   ------------
+   -- Traces --
+   ------------
+
+   procedure Traces (O : in out Object) is
+   begin
+      O.Traces := True;
+   end Traces;
 
    ----------------
    -- Types_From --

--- a/tools/wsdl2aws-generator.adb
+++ b/tools/wsdl2aws-generator.adb
@@ -918,15 +918,27 @@ package body WSDL2AWS.Generator is
             Text_IO.Put_Line (File, "   function " & L_Proc);
          end if;
 
-         if Mode in Stub_Header then
-            Put_Indent ('(');
-            Text_IO.Put (File, "Connection : AWS.Client.HTTP_Connection");
-         end if;
+         Put_Indent ('(');
+         Text_IO.Put (File, "Connection : AWS.Client.HTTP_Connection");
 
          if Input /= null then
             Text_IO.Put_Line (File, ";");
             Put_Indent;
             Input_Parameters;
+         end if;
+
+         if O.Gen_CB then
+            Text_IO.Put_Line (File, ";");
+            Put_Indent;
+            Text_IO.Put_Line
+               (File,
+                "Pre_Call_Callback  : Pre_Call_CB " &
+                   ":= Null_Pre_Call_Callback'Access;");
+            Put_Indent;
+            Text_IO.Put
+               (File,
+                "Post_Call_Callback : Post_Call_CB " &
+                   ":= Null_Post_Call_Callback'Access");
          end if;
 
          if Input /= null or else Mode in Stub_Header then
@@ -969,7 +981,22 @@ package body WSDL2AWS.Generator is
             Text_IO.Put (File, (Max_Len - 8) * ' ');
             Text_IO.Put
               (File, " : AWS.Client.Timeouts_Values := "
-               & To_String (O.Unit) & ".Timeouts");
+                  & To_String (O.Unit) & ".Timeouts");
+
+            if O.Gen_CB then
+               Text_IO.Put_Line (File, ";");
+               Put_Indent;
+               Text_IO.Put_Line
+                  (File,
+                   "Pre_Call_Callback  : Pre_Call_CB " &
+                      ":= Null_Pre_Call_Callback'Access;");
+               Put_Indent;
+               Text_IO.Put
+                  (File,
+                   "Post_Call_Callback : Post_Call_CB " &
+                      ":= Null_Post_Call_Callback'Access");
+            end if;
+
          end if;
 
          if Input /= null or else Mode in Stub_Header then

--- a/tools/wsdl2aws-generator.ads
+++ b/tools/wsdl2aws-generator.ads
@@ -116,6 +116,9 @@ package WSDL2AWS.Generator is
    --  definition are already coded in Ada, it is preferable to reuse them to
    --  not have to convert to/from both definitions.
 
+   procedure Traces (O : in out Object);
+   --  Generate traces callbacks from client stub code.
+
    procedure Types_From (O : in out Object; Spec : String);
    --  Use type definitions for Array and Record from this Ada spec instead of
    --  the one defined above. If there is no spec defined above, the procs are
@@ -172,6 +175,7 @@ private
       Stamp      : Boolean := True;
       Unit       : Unbounded_String;
       Spec       : Unbounded_String;
+      Traces     : Boolean := False;
       Types_Spec : Unbounded_String;
       Main       : Unbounded_String;
       Prefix     : Unbounded_String;

--- a/tools/wsdl2aws-main.adb
+++ b/tools/wsdl2aws-main.adb
@@ -145,7 +145,7 @@ procedure WSDL2AWS.Main is
       loop
          case Command_Line.Getopt
            ("d q a e: f v s o: p: proxy: pu: pp: doc wsdl cvs nostub noskel "
-            & "x: debug cb types: spec: main: n: timeouts:")
+            & "x: debug cb traces types: spec: main: n: timeouts:")
          is
             when ASCII.NUL => exit;
 
@@ -304,6 +304,9 @@ procedure WSDL2AWS.Main is
                      end case;
                   end;
 
+               elsif Command_Line.Full_Switch = "traces" then
+                  Generator.Traces (Gen);
+
                else
                   raise Syntax_Error;
                end if;
@@ -406,7 +409,8 @@ exception
       Put_Line ("   -cvs         Add CVS tag in unit's headers");
       Put_Line ("   -nostub      Do not create stub units");
       Put_Line ("   -noskel      Do not create skeleton units");
-      Put_Line ("   -cb          Generate SOAP callback routine");
+      Put_Line ("   -cb          Generate SOAP server callback routine");
+      Put_Line ("   -traces      Generate SOAP client callbacks");
       Put_Line ("   -x operation Exclude operation from code generation");
       Put_Line ("   -spec  spec  Use procs/types from Ada spec");
       Put_Line ("   -types spec  Use types from Ada spec");


### PR DESCRIPTION
This patch allows the user to attach logging call-backs to the generated SOAP client calls.