### PR TITLE
Fix WSDL generation to be compatible with Apache CXF.

### DIFF
--- a/regtests/0266_type_constraints/test.out
+++ b/regtests/0266_type_constraints/test.out
@@ -1,7 +1,6 @@
  12
 125
 ==============================
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 <xsd:simpleType name="T1">
 <xsd:restriction base="xsd:int">
 <xsd:minInclusive value=" 1"/>

--- a/regtests/0306_int_constraints/test.out
+++ b/regtests/0306_int_constraints/test.out
@@ -2,7 +2,6 @@
 -13
 -20
 ==============================
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 <xsd:simpleType name="T1">
 <xsd:restriction base="xsd:short">
 <xsd:minInclusive value="-20000"/>

--- a/tools/ada2wsdl-generator.adb
+++ b/tools/ada2wsdl-generator.adb
@@ -614,7 +614,10 @@ package body Ada2WSDL.Generator is
                Put_Line ("            <soap:body");
                Put_Line ("               encodingStyle="""
                            & "http://schemas.xmlsoap.org/soap/encoding/""");
-               Put_Line ("               namespace=""" & NS & '"');
+
+               if not (Options.Document and then Options.Literal) then
+                  Put_Line ("               namespace=""" & NS & '"');
+               end if;
 
                if Options.Literal then
                   Put_Line ("               use=""literal""/>");
@@ -1059,8 +1062,8 @@ package body Ada2WSDL.Generator is
          begin
             New_Line;
             Put
-              ("      <xsd:schema"
-               & " xmlns:xsd=""http://www.w3.org/2001/XMLSchema""");
+              ("      <schema"
+               & " xmlns=""http://www.w3.org/2001/XMLSchema""");
             New_Line;
             Put ("         targetNamespace=""" & NS & '"');
             Put_Line (">");
@@ -1088,7 +1091,7 @@ package body Ada2WSDL.Generator is
                end if;
             end loop;
 
-            Put_Line ("      </xsd:schema>");
+            Put_Line ("      </schema>");
          end Write_Schema_For;
 
          ----------------


### PR DESCRIPTION
The schema node does not have the xsd prefix. The wsdl:binding
must not include a namespace attribute for document/literal style.

The attribute namespace must not be used in document/literal binding.
See section "5.6.11 Namespaces for soapbind Elements" rule R2716 in
document "Basic Profile Version 1.0".

Fix some corresponding tests.

For R517-039.