### PR TITLE
Add support for TCP_No_Delay option.

### DIFF
--- a/docs/build.adb
+++ b/docs/build.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2014, AdaCore                     --
+--                     Copyright (C) 2000-2018, AdaCore                     --
 --                                                                          --
 --  This is free software;  you can redistribute it  and/or modify it       --
 --  under terms of the  GNU General Public License as published  by the     --
@@ -120,6 +120,7 @@ begin
    Add ("FT_CLIENT_DATA", Default.Force_Client_Data_Timeout);
    Add ("FT_SERVER_RESPONSE", Default.Force_Server_Response_Timeout);
    Add ("SEND_BUFFER_SIZE", Default.Send_Buffer_Size);
+   Add ("TCP_NO_DELAY", Default.TCP_No_Delay);
    Add ("SEND_TIMEOUT", Default.Send_Timeout);
    Add ("RECEIVE_TIMEOUT", Default.Receive_Timeout);
    Add ("LOGO_IMAGE", Default.Logo_Image);

--- a/docs/source/using_aws.rst
+++ b/docs/source/using_aws.rst
@@ -1188,6 +1188,14 @@ Current supported options are:
 
   The name of the status page to used. The default is |STATUS_PAGE|.
 
+*TCP_No_Delay (boolean)*
+
+  .. index:: TCP_No_Delay
+
+  This control the server's socket delay/no-delay option. This option
+  should be used for applications that require lower latency on every
+  packet sent. The default is |TCP_NO_DELAY|.
+
 *TLS_Ticket_Support (boolean)*
 
   .. index:: TLS_Ticket_Support

--- a/src/core/aws-config-set.adb
+++ b/src/core/aws-config-set.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2014, AdaCore                     --
+--                     Copyright (C) 2000-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -643,6 +643,15 @@ package body AWS.Config.Set is
    begin
       O.P (Status_Page).Str_Value := To_Unbounded_String (Value);
    end Status_Page;
+
+   ------------------
+   -- TCP_No_Delay --
+   ------------------
+
+   procedure TCP_No_Delay (O : in out Object; Value : Boolean) is
+   begin
+      O.P (TCP_No_Delay).Bool_Value := Value;
+   end TCP_No_Delay;
 
    ------------------------
    -- TLS_Ticket_Support --

--- a/src/core/aws-config-set.ads
+++ b/src/core/aws-config-set.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2014, AdaCore                     --
+--                     Copyright (C) 2000-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -87,6 +87,9 @@ package AWS.Config.Set is
    --  This is the socket buffer size used for sending data. Increasing this
    --  value will give better performances on slow or long distances
    --  connections.
+
+   procedure TCP_No_Delay (O : in out Object; Value : Boolean);
+   --  Set the TCP_NODELAY option for this server
 
    procedure Free_Slots_Keep_Alive_Limit
      (O : in out Object; Value : Natural);

--- a/src/core/aws-config.adb
+++ b/src/core/aws-config.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -734,6 +734,15 @@ package body AWS.Config is
    begin
       return To_String (O.P (Status_Page).Str_Value);
    end Status_Page;
+
+   ------------------
+   -- TCP_No_Delay --
+   ------------------
+
+   function TCP_No_Delay (O : Object) return Boolean is
+   begin
+      return O.P (TCP_No_Delay).Bool_Value;
+   end TCP_No_Delay;
 
    ------------------------
    -- TLS_Ticket_Support --

--- a/src/core/aws-config.ads
+++ b/src/core/aws-config.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -116,6 +116,9 @@ package AWS.Config is
    --  This is the socket buffer size used for sending data. Increasing this
    --  value will give better performances on slow or long distances
    --  connections.
+
+   function TCP_No_Delay (O : Object) return Boolean with Inline;
+   --  Returns wether the TCP_NODELAY option is set for this server
 
    function Free_Slots_Keep_Alive_Limit (O : Object) return Natural
      with Inline;
@@ -446,6 +449,7 @@ private
       Hotplug_Port,
       Max_Connection,
       Send_Buffer_Size,
+      TCP_No_Delay,
       Free_Slots_Keep_Alive_Limit,
       Keep_Alive_Force_Limit,
       Keep_Alive_Close_Limit,
@@ -638,6 +642,9 @@ private
 
                            Send_Buffer_Size                =>
                              (Nat, Default.Send_Buffer_Size),
+
+                           TCP_No_Delay                    =>
+                             (Bool, Default.TCP_No_Delay),
 
                            Free_Slots_Keep_Alive_Limit     =>
                              (Nat, Default.Free_Slots_Keep_Alive_Limit),

--- a/src/core/aws-default.ads
+++ b/src/core/aws-default.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -69,6 +69,7 @@ package AWS.Default with Pure is
    WebSocket_Message_Queue_Size    : constant          := 10;
    WebSocket_Timeout               : constant Duration := Eight_Hours;
    Send_Buffer_Size                : constant          := 0;
+   TCP_No_Delay                    : constant Boolean  := False;
    Free_Slots_Keep_Alive_Limit     : constant          := 1;
    Keep_Alive_Force_Limit          : constant          := 0;
    Keep_Alive_Close_Limit          : constant          := 0;

--- a/src/core/aws-server.adb
+++ b/src/core/aws-server.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2018, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -313,6 +313,9 @@ package body AWS.Server is
                Net.Set_Send_Buffer_Size
                  (Socket.all, AWS.Config.Send_Buffer_Size (TA.Server.Config));
             end if;
+
+            Net.Set_No_Delay
+              (Socket.all, AWS.Config.TCP_No_Delay (TA.Server.Config));
 
             TA.Server.Slots.Set (Socket, TA.Line);
 


### PR DESCRIPTION
This option can be used to control wether the TCP_NODELAY flag is to
be set on the server's sockets.

For R523-057.