### PR TITLE
Fix support for array of record as parameter.

### DIFF
--- a/regtests/0314_wsdl_array_rec_param/aws.ini
+++ b/regtests/0314_wsdl_array_rec_param/aws.ini
@@ -1,0 +1,1 @@
+reuse_address true

--- a/regtests/0314_wsdl_array_rec_param/src/aws_test.adb
+++ b/regtests/0314_wsdl_array_rec_param/src/aws_test.adb
@@ -1,0 +1,53 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                       Copyright (C) 2018, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Text_IO;
+
+package body AWS_Test is
+
+   use Ada.Text_IO;
+
+   -------------------
+   -- Get_Test_Name --
+   -------------------
+
+   function Get_Test_Name (Data : Data_Rec_Type) return String is
+   begin
+      Put_Line ("int: " & Integer'Image (Data.A_Int));
+      Put_Line ("flt: " & Float'Image (Data.A_Flt));
+      Put_Line ("str: " & To_String (Data.A_Str));
+
+      return "AWS_TEST";
+   end Get_Test_Name;
+
+   --------------------
+   -- Get_Test_Name2 --
+   --------------------
+
+   function Get_Test_Name2 (Data : Data_Rec_Array_Type) return String is
+   begin
+      for The_Item in Data'Range loop
+         Put_Line ("int: " & Integer'Image (Data(The_Item).A_Int));
+         Put_Line ("flt: " & Float'Image (Data(The_Item).A_Flt));
+         Put_Line ("str: " & To_String (Data(The_Item).A_Str));
+      end loop;
+
+      return "AWS_TEST2";
+   end Get_Test_Name2;
+
+end AWS_Test;

--- a/regtests/0314_wsdl_array_rec_param/src/aws_test.ads
+++ b/regtests/0314_wsdl_array_rec_param/src/aws_test.ads
@@ -1,0 +1,42 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                       Copyright (C) 2018, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Strings.Unbounded;
+
+with SOAP.Utils;
+
+package AWS_Test is
+
+   use Ada.Strings.Unbounded;
+
+   type Data_Rec_Type is record
+      A_Int : Integer;
+      A_Flt : Float;
+      A_Str : Unbounded_String;
+   end record;
+
+   type Data_Rec_Array_Type is array (Positive range <>) of Data_Rec_Type;
+   type Data_Rec_Array_Type_Access is access  Data_Rec_Array_Type;
+
+   package Data_Rec_Array_Type_Safe_Pointer is new SOAP.Utils.Safe_Pointers
+     (Data_Rec_Array_Type, Data_Rec_Array_Type_Access);
+
+  function Get_Test_Name (Data : Data_Rec_Type) return String;
+  function Get_Test_Name2 (Data : Data_Rec_Array_Type) return String;
+
+end AWS_Test;

--- a/regtests/0314_wsdl_array_rec_param/src/wsdl_array_rec_param.adb
+++ b/regtests/0314_wsdl_array_rec_param/src/wsdl_array_rec_param.adb
@@ -1,0 +1,76 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                       Copyright (C) 2018, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Text_IO;
+with Ada.Strings.Unbounded;
+
+with AWS.Config.Set;
+with AWS.Response;
+with AWS.Server;
+with AWS.Status;
+with SOAP.Dispatchers.Callback;
+
+with AWS_Test_Service.Client;
+with AWS_Test_Service.Cb;
+with AWS_Test_Service.Server;
+
+procedure WSDL_Array_Rec_Param is
+
+   use Ada.Text_IO;
+   use AWS;
+
+   function CB (Request : Status.Data) return Response.Data is
+      R : Response.Data;
+   begin
+      return R;
+   end CB;
+
+   WS   : AWS.Server.HTTP;
+   Conf : Config.Object := Config.Get_Current;
+   Disp : AWS_Test_Service.CB.Handler;
+
+begin
+   --  Start server
+
+   Config.Set.Server_Port
+     (Conf, AWS_Test_Service.Server.Port);
+
+   Disp := SOAP.Dispatchers.Callback.Create
+     (CB'Unrestricted_access,
+      AWS_Test_Service.CB.SOAP_CB'Access,
+      AWS_Test_Service.Schema);
+
+   AWS.Server.Start (WS, Disp, Conf);
+
+   --  Some client calls
+
+   Put_Line ("==========");
+   Put_Line (AWS_Test_Service.Client.Get_Test_Name
+     ((5, 5.0, Ada.Strings.Unbounded.To_Unbounded_String ("REC"))));
+
+   Put_Line ("==========");
+   Put_Line (AWS_Test_Service.Client.Get_Test_Name2
+     ((1 => ((6, 6.1, Ada.Strings.Unbounded.To_Unbounded_String ("ARR1"))))));
+
+   Put_Line ("==========");
+   Put_Line (AWS_Test_Service.Client.Get_Test_Name2
+     ((1 => ((6, 6.1, Ada.Strings.Unbounded.To_Unbounded_String ("ARR2"))),
+       2 => ((7, 7.2, Ada.Strings.Unbounded.To_Unbounded_String ("ARR3"))))));
+
+   AWS.Server.Shutdown (WS);
+end WSDL_Array_Rec_Param;

--- a/regtests/0314_wsdl_array_rec_param/test.opt
+++ b/regtests/0314_wsdl_array_rec_param/test.opt
@@ -1,0 +1,2 @@
+!asis DEAD
+!xmlada DEAD

--- a/regtests/0314_wsdl_array_rec_param/test.out
+++ b/regtests/0314_wsdl_array_rec_param/test.out
@@ -1,0 +1,18 @@
+==========
+int:  5
+flt:  5.00000E+00
+str: REC
+AWS_TEST
+==========
+int:  6
+flt:  6.10000E+00
+str: ARR1
+AWS_TEST2
+==========
+int:  6
+flt:  6.10000E+00
+str: ARR2
+int:  7
+flt:  7.20000E+00
+str: ARR3
+AWS_TEST2

--- a/regtests/0314_wsdl_array_rec_param/test.py
+++ b/regtests/0314_wsdl_array_rec_param/test.py
@@ -1,0 +1,17 @@
+import os
+from test_support import *
+
+os.mkdir('generated')
+os.chdir('src')
+
+exec_cmd('ada2wsdl', ['-q', '-P', '../wsdl_array_rec_param.gpr',
+                      '-a', 'http://localhost:9091',
+                      '-f', 'aws_test.ads', '-doc', '-lit',
+                      '-o', '../generated/aws_test.wsdl'])
+
+os.chdir('../generated')
+
+exec_cmd('wsdl2aws', ['-q', '-types', 'aws_test', '-cb', 'aws_test.wsdl'])
+
+os.chdir('..')
+build_and_run('wsdl_array_rec_param')

--- a/regtests/0314_wsdl_array_rec_param/wsdl_array_rec_param.gpr
+++ b/regtests/0314_wsdl_array_rec_param/wsdl_array_rec_param.gpr
@@ -1,0 +1,14 @@
+
+with "aws";
+
+project WSDL_Array_Rec_Param is
+
+   for Source_Dirs use ("src", "generated");
+
+   for main use ("wsdl_array_rec_param.adb");
+
+   package builder is
+      for default_switches ("Ada") use ("-m", "-x", "-gnat12");
+   end builder;
+
+end WSDL_Array_Rec_Param;

--- a/tools/wsdl2aws-generator.adb
+++ b/tools/wsdl2aws-generator.adb
@@ -2672,7 +2672,18 @@ package body WSDL2AWS.Generator is
               (Key   => Name & "." & To_String (N.Name),
                Value => WSDL.Types.Name
                           ((if N.Is_Set then N.E_Typ else N.Typ),
-                          NS => True));
+                           NS => True));
+
+            --  We also generate item.<field> for record inside arrays when
+            --  using the document/literal bindong style.
+
+            if O.Style = SOAP.WSDL.Schema.Document  then
+               Output_Schema_Definition
+                 (Key   => "item." & To_String (N.Name),
+                  Value => WSDL.Types.Name
+                    ((if N.Is_Set then N.E_Typ else N.Typ),
+                     NS => True));
+            end if;
 
             --  If N is an array, generate the schema definition for the
             --  array's elements.


### PR DESCRIPTION
When using the document/literal binding the schema definition for
fields of a record in an array was missing.

Add corresponding regression test.

For R606-051.