### PR TITLE
Synch with original ZLib-Ada repository

### DIFF
--- a/include/zlib.adb
+++ b/include/zlib.adb
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------
 --  ZLib for Ada thick binding.                               --
 --                                                            --
---  Copyright (C) 2002-2015, Dmitriy Anisimkov                --
+--  Copyright (C) 2002-2018, Dmitriy Anisimkov                --
 --                                                            --
 --  Open source license information is in the zlib.ads file.  --
 ----------------------------------------------------------------
@@ -223,7 +223,7 @@ package body ZLib is
 
       if Thin.Deflate_Init
            (To_Thin_Access (Filter.Strm),
-            Level      => Thin.Int (Level),
+            level      => Thin.Int (Level),
             method     => Thin.Int (Method),
             windowBits => Win_Bits,
             memLevel   => Thin.Int (Memory_Level),


### PR DESCRIPTION
ZLib-Ada original repository ssh://git.code.sf.net/p/zlib-ada/git
was accepted all AWS modifications and returns one back to AWS here.
At this stage include/zlib?* files absolutely equal to zlib-ada
sources after commit 4b89ae14ca71f8584f8202b8f9bf8874f26431a9.