### PR TITLE
awsascb produces invalid Ada code when called without parameters.

### DIFF
--- a/tools/awsascb
+++ b/tools/awsascb
@@ -9,8 +9,8 @@ pcks = sys.argv[1:]
 # Initialize the list of CB to aggregate passed on the command line
 
 if len(pcks) == 0:
-    print("missing Ada unit service names in argument")
-    exit
+    sys.stderr.write("missing Ada unit service names in argument\n")
+    sys.exit(1)
 
 # First: write the spec
 


### PR DESCRIPTION
When no command line parameters are given, awsascb does not terminate as intended, but proceeds to write Ada files where the parameter-dependent parts are missing.

It also writes the error message to the standard output stream, instead of the standard error stream where error messages should be written.