### PR TITLE
Addressed updates required by Ada 2012

### DIFF
--- a/demos/com/com_1.adb
+++ b/demos/com/com_1.adb
@@ -125,9 +125,7 @@ begin
    end loop;
 
    --  Exit when last message received
-
-   loop
-      exit when Last_Message_Received;
+   while not Last_Message_Received loop
       delay 1.0;
    end loop;
 

--- a/demos/com/com_2.adb
+++ b/demos/com/com_2.adb
@@ -104,9 +104,7 @@ begin
    end loop;
 
    --  Exit when last message received
-
-   loop
-      exit when Last_Message_Received;
+   while not Last_Message_Received loop
       delay 1.0;
    end loop;
 

--- a/demos/runme/runme_cb.adb
+++ b/demos/runme/runme_cb.adb
@@ -19,6 +19,7 @@
 with AWS.Messages;
 with AWS.Parameters;
 with AWS.Session;
+with Ada.Streams;
 
 package body Runme_CB is
 
@@ -78,7 +79,7 @@ package body Runme_CB is
             & "<p>go = "
             &  Parameters.Get (P_List, "go")
             & "<p>length = "
-            &  Positive'Image (Status.Content_Length (Request)));
+            &  Ada.Streams.Stream_Element_Offset'Image (Status.Content_Length (Request)));
 
       elsif URI = "/upload" then
          return Response.Build


### PR DESCRIPTION
Updated Demos to address compilation issues in Ada 2012:
com_1 and com_2 re-wrote loops to 'while not (status) loop'
runme_cb changed cast of message_body argument

replaces #52 