### PR TITLE
[Bug] Fixed incorrect Content-Length calculation in Upload

### DIFF
--- a/src/core/aws-client.adb
+++ b/src/core/aws-client.adb
@@ -1173,10 +1173,11 @@ package body AWS.Client is
       function Content_Length return Stream_Element_Offset is
       begin
          return 2 * Boundary'Length  -- 2 boundaries
-           + 2                       -- second one end with "--"
+           + 4                       -- two boundaries start with "--"
+           + 2                       -- second one ends with "--"
            + 10                      -- 5 lines with CR+LF
-           + CT'Length               -- content length header
-           + CD'Length               -- content disposition head
+           + CT'Length               -- content type header
+           + CD'Length               -- content disposition header
            + File_Size
            + 2;                      -- CR+LF after file data
       end Content_Length;


### PR DESCRIPTION
In file `src/core/aws-client.adb`, [line 1137](https://github.com/AdaCore/aws/blob/master/src/core/aws-client.adb#L1137), procedure `Upload`.

This procedure makes a `multipart/form-data` request in order to upload a file. [Line 1173](https://github.com/AdaCore/aws/blob/master/src/core/aws-client.adb#L1173) defines `Content_Length` function to calculate the form payload length of this request.

This calculation function, however, is incorrect and should return 4 bytes larger. The calculation of boundary length happens in [line 1175](https://github.com/AdaCore/aws/blob/master/src/core/aws-client.adb#L1175), which simply takes `Boundary'Length`. `Boundary` was defined in [line 1149](https://github.com/AdaCore/aws/blob/master/src/core/aws-client.adb#L1149) and does not have "--" prefix, while [Line 1197](https://github.com/AdaCore/aws/blob/master/src/core/aws-client.adb#L1197) and [1229](https://github.com/AdaCore/aws/blob/master/src/core/aws-client.adb#L1229) sends boundary with a "--" prefix (defined as `Pref_Suf`). 

Note the packet analyzer (Wireshark) reports 4 more bytes in this http packet (last line). The data `2d2d0d0a`, are exactly the hex of `--\r\n` in ASCII. This also highlights the previous error.
![image](https://user-images.githubusercontent.com/4940216/49688439-0c2b0680-fb4d-11e8-8580-e14895f9c4d8.png)

I have fixed this issue by adding +4 in the function. Some incorrect comments are also fixed.

Thanks.