### PR TITLE
Windows 2016 error output equal to 2012 for 0245_errcon test

### DIFF
--- a/regtests/0245_errcon/test.opt
+++ b/regtests/0245_errcon/test.opt
@@ -1,6 +1,7 @@
 vxworks6-6.6 DEAD
 windows-2012,ipv4 OUT test-win7-ipv4.out
 windows-2012,gnat OUT test-win2012.out
+windows-2016,gnat OUT test-win2012.out
 windows-2008R2,ipv4 OUT test-win7-ipv4.out
 windows-2012R2,ipv4 OUT test-win7-ipv4.out
 windows-7,ipv4 OUT test-win7-ipv4.out


### PR DESCRIPTION
S121-016