### PR TITLE
Remove IPv6 complexity from 0067_hostip test

### DIFF
--- a/regtests/0067_hostip/hostip.adb
+++ b/regtests/0067_hostip/hostip.adb
@@ -33,7 +33,6 @@ procedure HostIP is
    use AWS;
 
    WS : Server.HTTP;
-   W6 : Server.HTTP;
 
    function CB (Request : Status.Data) return Response.Data is
    begin
@@ -58,26 +57,15 @@ begin
    Config.Set.Server_Host     (CFG, "localhost");
    Config.Set.Server_Name     (CFG, "hostip");
    Config.Set.Server_Port     (CFG, 0);
-   Config.Set.Protocol_Family (CFG, "FAMILY_INET");
    Config.Set.Max_Connection  (CFG, 5);
 
    Server.Start (WS, CB'Unrestricted_Access, CFG);
-
-   if AWS.Net.IPv6_Available then
-      Config.Set.Protocol_Family (CFG, "FAMILY_INET6");
-      Config.Set.Server_Port (CFG, Server.Status.Port (WS));
-      Server.Start (W6, CB'Unrestricted_Access, CFG);
-   end if;
 
    Text_IO.Put_Line ("started"); Ada.Text_IO.Flush;
 
    Call_It;
 
    Server.Shutdown (WS);
-
-   if AWS.Net.IPv6_Available then
-      Server.Shutdown (W6);
-   end if;
 
    Text_IO.Put_Line ("shutdown");
 end HostIP;


### PR DESCRIPTION
S124-057

The removed code became not necessary because server host resolution priority
became for IPv6.