### PR TITLE
Make deflate priority last in Accept-Encoding default header

### DIFF
--- a/regtests/0118_test_net_log/test.out
+++ b/regtests/0118_test_net_log/test.out
@@ -5,7 +5,7 @@
 Connection: Close
 Host:
 Accept: text/html, */*
-Accept-Encoding: deflate, gzip
+Accept-Encoding: gzip, deflate
 Accept-Language: fr, ru, us
 User-Agent:
 
@@ -28,7 +28,7 @@ Content-Length: 16
 Connection: Close
 Host:
 Accept: text/html, */*
-Accept-Encoding: deflate, gzip
+Accept-Encoding: gzip, deflate
 Accept-Language: fr, ru, us
 User-Agent:
 

--- a/regtests/0317_hide_id/test.out
+++ b/regtests/0317_hide_id/test.out
@@ -6,7 +6,7 @@ Connection: Close
 X-Request: 1st-First
 Host:
 Accept: text/html, */*
-Accept-Encoding: deflate, gzip
+Accept-Encoding: gzip, deflate
 Accept-Language: fr, ru, us
 User-Agent: AWS (Ada Web Server) v##.#
 
@@ -32,7 +32,7 @@ Connection: Close
 X-Request: 2nd-Second
 Host:
 Accept: text/html, */*
-Accept-Encoding: deflate, gzip
+Accept-Encoding: gzip, deflate
 Accept-Language: fr, ru, us
 User-Agent: justme_client
 
@@ -58,7 +58,7 @@ Connection: Close
 X-Request: 3rd-Third
 Host:
 Accept: text/html, */*
-Accept-Encoding: deflate, gzip
+Accept-Encoding: gzip, deflate
 Accept-Language: fr, ru, us
 
 

--- a/src/core/aws-client-http_utils.adb
+++ b/src/core/aws-client-http_utils.adb
@@ -816,7 +816,7 @@ package body AWS.Client.HTTP_Utils is
 
       Send_Header
         (Sock.all, Messages.Accept_Encoding_Token,
-         Messages.Accept_Encoding'Access, "deflate, gzip", Header);
+         Messages.Accept_Encoding'Access, "gzip, deflate", Header);
 
       Send_Header
         (Sock.all, Messages.Accept_Language_Token,


### PR DESCRIPTION
S201-013

Some web servers provide deflate compressed body wrong.
See: https://stackoverflow.com/questions/3932117
Detected in https://api.cognitive.microsofttranslator.com/translate