### PR TITLE
Add support for fractional-seconds for XSD_Time_Instant.

### DIFF
--- a/regtests/0161_workorder/test.py
+++ b/regtests/0161_workorder/test.py
@@ -5,5 +5,5 @@ build('workorder')
 run('workorder', output_file="out.tmp")
 
 for l in open('out.tmp').readlines():
-    print(re.sub(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d([\+\-]\d\d:\d\d|Z)",
+    print(re.sub(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d([\+\-]\d\d:\d\d|Z)",
                  "XXXX-XX-XXTXX:XX:XXZ", l))

--- a/regtests/0274_doclit2/test.py
+++ b/regtests/0274_doclit2/test.py
@@ -7,8 +7,9 @@ run('dl2_server', output_file="out.tmp")
 
 # Change dateTime
 
-r1 = r'(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)'
-r2 = r'(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d[\+\-]\d\d:\d\d)'
+r1 = r'(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\dZ)'
+r2 = r'(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d[\+\-]\d\d:\d\d)'
+r3 = r'(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)'
 
 for l in open('out.tmp').readlines():
-    print(re.sub(r1+r'|'+r2, "XXXX-XX-XXTXX:XX:XXZ", l))
+    print(re.sub(r1+r'|'+r2+r'|'+r3, "XXXX-XX-XXTXX:XX:XXZ", l))

--- a/src/soap/soap-types.adb
+++ b/src/soap/soap-types.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2018, AdaCore                     --
+--                     Copyright (C) 2000-2019, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -791,6 +791,8 @@ package body SOAP.Types is
 
    overriding function Image (O : XSD_Time_Instant) return String is
 
+      use type GNAT.Calendar.Time_IO.Picture_String;
+
       function Image
         (Timezone : Calendar.Time_Zones.Time_Offset) return String;
       --  Returns Image for the TZ
@@ -839,8 +841,14 @@ package body SOAP.Types is
          end if;
       end Image;
 
+      Has_Sub_Second : constant Boolean :=
+                         GNAT.Calendar.Sub_Second (O.T) /= 0.0;
+
+      Format         : constant GNAT.Calendar.Time_IO.Picture_String :=
+                         "%Y-%m-%dT%H:%M:%S"
+                         & (if Has_Sub_Second then ".%i" else "");
    begin
-      return GNAT.Calendar.Time_IO.Image (O.T, "%Y-%m-%dT%H:%M:%S")
+      return GNAT.Calendar.Time_IO.Image (O.T, Format)
         & Image (Calendar.Time_Zones.UTC_Time_Offset (O.T));
    end Image;
 


### PR DESCRIPTION
Fractional seconds are now properly parsed and also serialized when
a time-instant is sent over in a payload.

Update some tests to conform to this new support.

Fixes S723-002.