### PR TITLE
0245_errcon/test.opt: Move linux-rhES7 match before 'gnat'

### DIFF
--- a/regtests/0245_errcon/test.opt
+++ b/regtests/0245_errcon/test.opt
@@ -15,7 +15,7 @@ darwin,gnat OUT test-darwin.out
 freebsd,!ipv4 OUT test-freebsd-ipv6.out
 freebsd,ipv4 OUT test-freebsd-ipv4.out
 vxworks6,!vxworks6-6.6 OUT test-vxworks.out
+linux-rhES7 OUT test-rhES7.out
 gnat OUT test.out
 ipv6 OUT test-ipv6.out
 ipv4,!vxworks6-6.6 OUT test-ipv4.out
-linux-rhES7 OUT test-rhES7.out


### PR DESCRIPTION
'gnat' is a discriminant which is present when running in the linux-rhES7
configuration, so the corresponding line was selected, because it was
ahead of the line added to match 'linux-rhES7'. Moving it ahead avoids
that issue.

For S806-014