### PR TITLE
Fix check for reading above web-root when using encoded paths.

### DIFF
--- a/regtests/0323_above_web_root/above_wr.adb
+++ b/regtests/0323_above_web_root/above_wr.adb
@@ -1,0 +1,63 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                      Copyright (C) 2019, AdaCore                         --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Exceptions; use Ada.Exceptions;
+with Ada.Text_IO;    use Ada.Text_IO;
+with AWS.URL;        use AWS.URL;
+
+procedure Above_WR is
+
+   procedure Test (URL : String) is
+      O : Object;
+   begin
+      O := Parse (URL);
+
+      Put_Line (URL);
+      Put_Line (AWS.URL.URL (O));
+      Put_Line ("   Server     : " & Host (O));
+      Put_Line ("   Port       : " & Port (O));
+      Put_Line ("   Path       : " & Path (O));
+      Put_Line ("   File       : " & File (O));
+      Put_Line ("   Parameters : " & Parameters (O));
+      Put_Line ("   URI        : " & Pathname_And_Parameters (O));
+
+      Normalize (O);
+
+      Put_Line ("   *");
+      Put_Line ("   Server     : " & Host (O));
+      Put_Line ("   Port       : " & Port (O));
+      Put_Line ("   Path       : " & Path (O));
+      Put_Line ("   File       : " & File (O));
+      Put_Line ("   Parameters : " & Parameters (O));
+      Put_Line ("   URI        : " & Pathname_And_Parameters (O));
+
+   exception
+      when E : URL_Error =>
+         Put_Line ("Error on " & URL & " - " & Exception_Message (E));
+   end Test;
+
+begin
+   Test ("http://www.myserver.com:89/api/../../?value=1");
+   Test ("http://www.myserver.com:89/../../?value=2");
+   Test ("http://www.myserver.com:89/api/../..?value=3");
+   Test ("http://www.myserver.com:89/../..?value=4");
+   Test ("http://www.myserver.com:89/api/..%2F..%2F?value=5");
+   Test ("http://www.myserver.com:89/..%2F..%2F?value=6");
+   Test ("http://www.myserver.com:89/api/..%2F..?value=7");
+   Test ("http://www.myserver.com:89/..%2F..?value=8");
+end Above_WR;

--- a/regtests/0323_above_web_root/above_wr.gpr
+++ b/regtests/0323_above_web_root/above_wr.gpr
@@ -1,0 +1,24 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                      Copyright (C) 2019, AdaCore                         --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with "aws";
+
+project Above_WR is
+   for Source_Dirs use (".");
+   for Main use ("above_wr.adb");
+end Above_WR;

--- a/regtests/0323_above_web_root/test.out
+++ b/regtests/0323_above_web_root/test.out
@@ -1,0 +1,8 @@
+Error on http://www.myserver.com:89/api/../../?value=1 - Wrong URL: (/../) Reference Web root parent directory.
+Error on http://www.myserver.com:89/../../?value=2 - Wrong URL: (/../../) Reference Web root parent directory.
+Error on http://www.myserver.com:89/api/../..?value=3 - Wrong URL: (/..) Reference Web root parent directory.
+Error on http://www.myserver.com:89/../..?value=4 - Wrong URL: (/../..) Reference Web root parent directory.
+Error on http://www.myserver.com:89/api/..%2F..%2F?value=5 - Wrong URL: (/../) Reference Web root parent directory.
+Error on http://www.myserver.com:89/..%2F..%2F?value=6 - Wrong URL: (/../../) Reference Web root parent directory.
+Error on http://www.myserver.com:89/api/..%2F..?value=7 - Wrong URL: (/..) Reference Web root parent directory.
+Error on http://www.myserver.com:89/..%2F..?value=8 - Wrong URL: (/../..) Reference Web root parent directory.

--- a/regtests/0323_above_web_root/test.py
+++ b/regtests/0323_above_web_root/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+build_and_run('above_wr');

--- a/src/core/aws-url-set.adb
+++ b/src/core/aws-url-set.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2007-2018, AdaCore                     --
+--                     Copyright (C) 2007-2019, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -206,7 +206,7 @@ package body AWS.URL.Set is
          ---------------------
 
          procedure Parse_Path_File (Start : Positive) is
-            PF : constant String := URL (Start .. URL'Last);
+            PF : constant String := Decode (URL (Start .. URL'Last));
             I3 : constant Natural :=
                    Strings.Fixed.Index (PF, "/", Strings.Backward);
          begin
@@ -216,7 +216,7 @@ package body AWS.URL.Set is
                --  which must be part of the path.
 
                declare
-                  File : constant String := Decode (PF);
+                  File : constant String := PF;
                begin
                   if File = ".." or else File = "." then
                      Item.Path := +File;
@@ -232,13 +232,13 @@ package body AWS.URL.Set is
                --  parent directories which must be part of the path.
 
                declare
-                  File : constant String := Decode (URL (I3 + 1 .. URL'Last));
+                  File : constant String := PF (I3 + 1 .. PF'Last);
                begin
                   if File = ".." or else File = "." then
-                     Item.Path := +Decode (PF);
+                     Item.Path := +PF;
                      Item.File := +"";
                   else
-                     Item.Path := +Decode (URL (Start .. I3));
+                     Item.Path := +PF (PF'First .. I3);
                      Item.File := +File;
                   end if;
                end;


### PR DESCRIPTION
If the path in the URL encode some directory separator as %2F for
example it was possible to access files above web-root.

Add corresponding regression test.

Fixes SA23-003.