### PR TITLE
aws-os_lib-tmplt.c: fix pointer conversion issues under x86_64-pc-min…

### DIFF
--- a/config/setup/aws-os_lib-tmplt.c
+++ b/config/setup/aws-os_lib-tmplt.c
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2012-2018, AdaCore                     --
+--                     Copyright (C) 2012-2020, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -319,7 +319,8 @@ CND(FD_SETSIZE, "Max fd value");
 #define SIZEOF_sin_family sizeof (sa.sin_family) * 8
 CND(SIZEOF_sin_family, "Size of sa.sin_family");
 
-#define SIN_FAMILY_OFFSET (long)((long)&sa.sin_family - (long)&sa)
+#define SIN_FAMILY_OFFSET (uintptr_t)((uintptr_t)&sa.sin_family    \
+                                    - (uintptr_t)&sa)
 /*NOGEN*/ CND(SIN_FAMILY_OFFSET, "sin_family offset in record");
 }
 
@@ -332,9 +333,11 @@ CND(SIZEOF_sin_family, "Size of sa.sin_family");
 #else
   const struct addrinfo ai;
 
-#define AI_FAMILY_OFFSET (long)((long)&ai.ai_family - (long)&ai)
-#define AI_CANONNAME_OFFSET (long)((long)&ai.ai_canonname - (long)&ai)
-#define AI_ADDR_OFFSET (long)((long)&ai.ai_addr - (long)&ai)
+#define AI_FAMILY_OFFSET (uintptr_t)((uintptr_t)&ai.ai_family \
+                                     - (uintptr_t)&ai)
+#define AI_CANONNAME_OFFSET (uintptr_t)((uintptr_t)&ai.ai_canonname \
+                                        - (uintptr_t)&ai)
+#define AI_ADDR_OFFSET (uintptr_t)((uintptr_t)&ai.ai_addr - (uintptr_t)&ai)
 #endif
 
 /*NOGEN*/ CND(AI_FAMILY_OFFSET, "???");


### PR DESCRIPTION
…gw32

With x86_64-pc-mingw32 sizeof(void *) != sizeof(long), this triggers the
following warnings / errors:

aws-os_lib-tmplt.c:342:11: warning: asm operand 1 probably doesn't match
constraints
  342 | /*NOGEN*/ CND(AI_ADDR_OFFSET, "???");
      |           ^~~
aws-os_lib-tmplt.c:323:11: error: impossible constraint in 'asm'
  323 | /*NOGEN*/ CND(SIN_FAMILY_OFFSET, "sin_family offset in record");
      |           ^~~
aws-os_lib-tmplt.c:340:11: error: impossible constraint in 'asm'
  340 | /*NOGEN*/ CND(AI_FAMILY_OFFSET, "???");
      |           ^~~
aws-os_lib-tmplt.c:341:11: error: impossible constraint in 'asm'
  341 | /*NOGEN*/ CND(AI_CANONNAME_OFFSET, "???");
      |           ^~~
aws-os_lib-tmplt.c:342:11: error: impossible constraint in 'asm'
  342 | /*NOGEN*/ CND(AI_ADDR_OFFSET, "???");
      |           ^~~

Let's use uintptr_t instead of long for the pointers.

TN: T125-001