### PR TITLE
Pass correct From_Client to Send procedure

### DIFF
--- a/src/core/aws-net-websocket.adb
+++ b/src/core/aws-net-websocket.adb
@@ -625,7 +625,8 @@ package body AWS.Net.WebSocket is
          Socket.State.Kind := Text;
       end if;
 
-      Socket.P_State.State.Send (Socket, Message);
+      Socket.P_State.State.Send
+         (Socket, Message, From_Client => Is_Client_Side (Socket));
    end Send;
 
    --------------


### PR DESCRIPTION
It seems From_Client is lost for binary web socket messages