### PR TITLE
Rework the session startup to avoid a potentially blocking operation.

### DIFF
--- a/src/core/aws-session-control.adb
+++ b/src/core/aws-session-control.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2012, AdaCore                     --
+--                     Copyright (C) 2000-2020, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -80,9 +80,18 @@ package body AWS.Session.Control is
    -----------
 
    procedure Start
-     (Session_Check_Interval : Duration; Session_Lifetime : Duration) is
+     (Session_Check_Interval : Duration; Session_Lifetime : Duration)
+   is
+      Init_Cleaner : Boolean;
    begin
-      Cleaner_Control.Start (Session_Check_Interval, Session_Lifetime);
+      Cleaner_Control.Start
+        (Session_Check_Interval, Session_Lifetime, Init_Cleaner);
+
+      --  Wether the cleaner task is to be initialized
+
+      if Init_Cleaner then
+         Cleaner_Task := new Cleaner;
+      end if;
    end Start;
 
 end AWS.Session.Control;

--- a/src/core/aws-session.adb
+++ b/src/core/aws-session.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2020, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -318,14 +318,18 @@ package body AWS.Session is
       -- Start --
       -----------
 
-      procedure Start (Check_Interval : Duration; Lifetime : Duration) is
+      procedure Start
+        (Check_Interval : Duration;
+         Lifetime       : Duration;
+         Init_Cleaner   : out Boolean) is
       begin
          S_Count := S_Count + 1;
+         Init_Cleaner := False;
 
          if S_Count = 1 then
             Session.Check_Interval := Start.Check_Interval;
             Session.Lifetime       := Real_Time.To_Time_Span (Start.Lifetime);
-            Cleaner_Task := new Cleaner;
+            Init_Cleaner := True;
          end if;
       end Start;
 

--- a/src/core/aws-session.ads
+++ b/src/core/aws-session.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2020, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -252,7 +252,10 @@ private
 
    protected Cleaner_Control is
 
-      procedure Start (Check_Interval : Duration; Lifetime : Duration);
+      procedure Start
+        (Check_Interval : Duration;
+         Lifetime       : Duration;
+         Init_Cleaner   : out Boolean);
       --  Launch the cleaner task the first time and does nothing after
 
       procedure Stop (Need_Release : out Boolean);


### PR DESCRIPTION
Indeed, starting a task from a protected object is a potentially
blocking operation and is detected when using the global
configuration pragma Detect_Blocking.

Fixes T415-011.