### PR TITLE
Pass ADAFLAGS to include.gpr and add CPPFLAGS to CFLAGS.

### DIFF
--- a/include/include.gpr
+++ b/include/include.gpr
@@ -64,6 +64,10 @@ library project Include is
          when others =>
             null;
       end case;
+
+      for Default_Switches ("Ada") use
+        Compiler'Default_Switches ("Ada")
+        & Shared.Adaflags;
    end Compiler;
 
    -------------

--- a/shared.gpr
+++ b/shared.gpr
@@ -90,6 +90,7 @@ abstract project Shared is
 
    Adaflags := External_As_List ("ADAFLAGS", " ");
    Cflags   := External_As_List ("CFLAGS", " ");
+   Cppflags := External_As_List ("CPPFLAGS", " ");
    Ldflags  := External_As_List ("LDFLAGS", " ");
 
    ---------
@@ -157,7 +158,7 @@ abstract project Shared is
       for Default_Switches ("Ada") use
         Compiler'Default_Switches ("Ada") & Adaflags;
       for Default_Switches ("C") use
-        Compiler'Default_Switches ("C") & Cflags;
+        Compiler'Default_Switches ("C") & Cflags & Cppflags;
 
    end Compiler;
 

--- a/tools/awsres.adb
+++ b/tools/awsres.adb
@@ -367,7 +367,7 @@ procedure AwsRes is
 
    function Header return String is
    begin
-      return "--  AWSRes v" & Version & " - Genarated on " &
+      return "--  AWSRes v" & Version & " - Generated on " &
         GNAT.Calendar.Time_IO.Image (Calendar.Clock, "%B %d %Y at %T");
    end Header;
 

--- a/tools/wsdl2aws-wsdl-parser.adb
+++ b/tools/wsdl2aws-wsdl-parser.adb
@@ -1391,7 +1391,7 @@ package body WSDL2AWS.WSDL.Parser is
 
             if N = null then
                if SOAP.XML.Get_Attr_Value (Parent, "abstract") = "true" then
-                  raise WSDL_Error with "abstract complexType not suported.";
+                  raise WSDL_Error with "abstract complexType not supported.";
                end if;
             end if;
          end;


### PR DESCRIPTION
Pass ADAFLAGS to include.gpr and add CPPFLAGS to CFLAGS.

This patch does not apply the common style flags to include/*, it only
allow explicit user flags (ADAFLAGS) to override default flags.

The External is in shared.gpr so that there is only one environment
lookup for each variable.