### PR TITLE
Rework AWS client's API to avoid stressing too much the stack.

### DIFF
--- a/regtests/0326_big_post/big_post.adb
+++ b/regtests/0326_big_post/big_post.adb
@@ -1,0 +1,73 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                       Copyright (C) 2020, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Streams;
+with Ada.Text_IO;
+
+with AWS.Client;
+with AWS.Messages;
+with AWS.MIME;
+with AWS.Net.Log;
+with AWS.Parameters;
+with AWS.Response;
+with AWS.Server.Status;
+with AWS.Status;
+with AWS.Translator;
+with AWS.Utils;
+
+procedure Big_Post is
+
+   use Ada;
+   use Ada.Streams;
+   use AWS;
+
+   type String_Access is access String;
+
+   --------
+   -- CB --
+   --------
+
+   function CB (Request : Status.Data) return Response.Data is
+   begin
+      Text_IO.Put_Line
+        ("Length payload: " & Status.Content_Length (Request)'Img);
+      return Response.Build (MIME.Text_HTML, "ok");
+   end CB;
+
+   WS     : Server.HTTP;
+   M_Body : String_Access;
+   R      : Response.Data;
+
+begin
+   Server.Start (WS, "Big Post", CB'Unrestricted_Access, Port => 0);
+
+   Text_IO.Put_Line ("started");
+   Text_IO.Flush;
+
+   M_Body := new String'(1 .. 16_000_000 => 'a');
+
+   R := Client.Post
+          (Server.Status.Local_URL (WS) & "/big_post",
+           M_Body.all,
+           Content_Type => MIME.Text_HTML);
+
+   Text_IO.Put_Line (Response.Message_Body (R));
+
+   Server.Shutdown (WS);
+   Text_IO.Put_Line ("shutdown");
+end Big_Post;

--- a/regtests/0326_big_post/big_post.gpr
+++ b/regtests/0326_big_post/big_post.gpr
@@ -1,0 +1,23 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                       Copyright (C) 2020, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with "aws";
+
+project Big_Post is
+   for Main use ("big_post.adb");
+end Big_Post;

--- a/regtests/0326_big_post/test.out
+++ b/regtests/0326_big_post/test.out
@@ -1,0 +1,4 @@
+started
+Length payload:  16000000
+ok
+shutdown

--- a/regtests/0326_big_post/test.py
+++ b/regtests/0326_big_post/test.py
@@ -1,0 +1,3 @@
+from test_support import *
+
+build_and_run('big_post');

--- a/src/core/aws-net.adb
+++ b/src/core/aws-net.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2019, AdaCore                     --
+--                     Copyright (C) 2000-2020, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -442,10 +442,12 @@ package body AWS.Net is
      (Socket : Socket_Type'Class; Data : Stream_Element_Array)
    is
       use Ada.Real_Time;
-      Save  : constant Boolean := Socket.C.Can_Wait;
-      First : Stream_Element_Offset := Data'First;
-      Last  : Stream_Element_Offset;
-      Stamp : Time;
+      Chunk_Size : constant := 100 * 1_024;
+      Save       : constant Boolean := Socket.C.Can_Wait;
+      First      : Stream_Element_Offset := Data'First;
+      Chunk_Last : Stream_Element_Offset := Data'Last;
+      Last       : Stream_Element_Offset;
+      Stamp      : Time;
    begin
       Socket.C.Can_Wait := True;
 
@@ -466,7 +468,10 @@ package body AWS.Net is
       end if;
 
       loop
-         Send (Socket, Data (First .. Data'Last), Last);
+         Chunk_Last :=
+           Stream_Element_Offset'Min (Data'Last, First + Chunk_Size - 1);
+
+         Send (Socket, Data (First .. Chunk_Last), Last);
 
          exit when Last = Data'Last;
 


### PR DESCRIPTION
When sending large payload over a socket with AWS.Client.Post we
ensure that no copy of the data is made on the stack to avoid a
stack overflow. This is especially important when a call is made
from a task where the stack may be limited.

Add corresponding regression test.

Fixes T527-014.