### PR TITLE
Big upload has to be allowed on server side

### DIFF
--- a/regtests/0326_big_post/big_post.adb
+++ b/regtests/0326_big_post/big_post.adb
@@ -44,6 +44,10 @@ procedure Big_Post is
 
    function CB (Request : Status.Data) return Response.Data is
    begin
+      if not Status.Is_Body_Uploaded (Request) then
+         Server.Get_Message_Body;
+      end if;
+
       Text_IO.Put_Line
         ("Length payload: " & Status.Content_Length (Request)'Img);
       return Response.Build (MIME.Text_HTML, "ok");


### PR DESCRIPTION
T605-046

If upload size more than Upload_Size_Limit, the server side has to check
Status.Is_Body_Uploaded and call Server.Get_Message_Body if necessary.