### PR TITLE
Fix C compilation warning

### DIFF
--- a/config/ssl/openssl/wrappers.c
+++ b/config/ssl/openssl/wrappers.c
@@ -89,12 +89,12 @@ int __aws_CRYPTO_num_locks(void) {
   return CRYPTO_num_locks();
 }
 
-void __aws_SSL_set_tmp_rsa_callback(SSL_CTX *ctx,
+void __aws_SSL_set_tmp_rsa_callback(SSL *ssl,
 				    RSA *(*tmp_rsa_callback)(SSL *ssl,
 							     int is_export,
 							     int keylength))
 {
-  SSL_set_tmp_rsa_callback(ctx, tmp_rsa_callback);
+  SSL_set_tmp_rsa_callback(ssl, tmp_rsa_callback);
 }
 
 int __aws_SSL_library_init(void)


### PR DESCRIPTION
wrappers.c:97:28: warning: passing argument 1 of 'SSL_set_tmp_rsa_callback'
  from incompatible pointer type [-Wincompatible-pointer-types]

This mistake was inherited from OpenSSL HTML documentation page
https://www.openssl.org/docs/man1.0.2/man3/SSL_set_tmp_rsa_callback.html
The documentation in OpenSSL sources is right.