### PR TITLE
Add missing calls to On_Close

### DIFF
--- a/src/core/aws-net-websocket-registry.ads
+++ b/src/core/aws-net-websocket-registry.ads
@@ -141,7 +141,7 @@ package AWS.Net.WebSocket.Registry is
      with Pre => To /= No_Recipient;
    --  Close connections
 
-   --  Targetting a single WebSocket, these routines are equivalent to the
+   --  Targeting a single WebSocket, these routines are equivalent to the
    --  Net.WebSocket ones but are thread-safe. That is, they can be mixed
    --  with other WebSocket activity to and from the clients.
 

--- a/src/core/aws-net-websocket.adb
+++ b/src/core/aws-net-websocket.adb
@@ -503,6 +503,7 @@ package body AWS.Net.WebSocket is
                  and then not Utils.Is_Valid_UTF8 (Message)
                then
                   On_Error (WebSocket);
+                  WebSocket.On_Close (To_String (Message));
                   WebSocket.Shutdown;
                   On_Free (WebSocket);
                else
@@ -634,7 +635,9 @@ package body AWS.Net.WebSocket is
      (Socket : Object;
       How    : Shutmode_Type := Shut_Read_Write) is
    begin
-      Socket.Socket.Shutdown (How);
+      if Socket.Socket /= null then
+         Socket.Socket.Shutdown (How);
+      end if;
    end Shutdown;
 
    ---------


### PR DESCRIPTION
When the websocket is closed on error, we should still call On_Close
 so that user-defined cleanup is run.
(Send): Avoid a case of double-free