### PR TITLE
Config.Ini.Read: review documentation and fix implemenation.

### DIFF
--- a/src/core/aws-config-ini.adb
+++ b/src/core/aws-config-ini.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2019, AdaCore                     --
+--                     Copyright (C) 2000-2020, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -189,6 +189,13 @@ package body AWS.Config.Ini is
       Text_IO.Close (File);
 
    exception
+      when Constraint_Error =>
+         if Text_IO.Is_Open (File) then
+            Text_IO.Close (File);
+         end if;
+
+         raise;
+
       when others =>
          if Text_IO.Is_Open (File) then
             Text_IO.Close (File);

--- a/src/core/aws-config-ini.ads
+++ b/src/core/aws-config-ini.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2012, AdaCore                     --
+--                     Copyright (C) 2000-2020, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -41,8 +41,7 @@ package AWS.Config.Ini is
      (Config   : in out Object;
       Filename : String);
    --  Read Filename and update the configuration object with the
-   --  options read from it. Raises Ada.Text_IO.Name_Error if Filename does
-   --  not exist. Raises Constraint_Error in case of wrong any parameter name
-   --  or value.
+   --  options read from it. Raises Constraint_Error in case of wrong
+   --  any parameter name or value.
 
 end AWS.Config.Ini;


### PR DESCRIPTION
All exceptions where masked which was not compliant with the comments.

Now this routine properly propagates the exception Constraint_Error in case
of erronous option name or value.

The regression was introduced in 05a2aea when fixing a possible resource
leak failing to close the file descriptor of the configuration file in
case or error.

For T707-002.