### PR TITLE
ada2wsdl: avoid a possible use before initialization.

### DIFF
--- a/tools/ada2wsdl-parser.adb
+++ b/tools/ada2wsdl-parser.adb
@@ -542,7 +542,7 @@ package body Ada2WSDL.Parser is
                Len          : Unbounded_String;
                Lower, Upper : Long_Long_Integer;
                Type_Suffix  : Unbounded_String;
-               Array_Len    : Integer;
+               Array_Len    : Integer := 0;
             begin
                Get_Range (T_Decl, Lower, Upper);
 


### PR DESCRIPTION
Possible fix for T915-027.