### PR TITLE
Set pygments style to None.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,7 @@ exclude_patterns = []
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = None 
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
This change is tied to the migration to Sphinx 3.2.
Setting pygments_style to None keeps the background color used for examples unchanged.