### PR TITLE
More common end-of-stream detection

### DIFF
--- a/regtests/0330_zlib_stream_end/test.out
+++ b/regtests/0330_zlib_stream_end/test.out
@@ -2,33 +2,44 @@
  2
  3
  4
+ 0 0
 Created file with length  18
  1
  2
  3
  4
+End of stream: BUF_ERROR
+
 Created file with length  17
  1
  2
  3
  4
+End of stream: BUF_ERROR
+
 Created file with length  16
  1
  2
  3
  4
+End of stream: BUF_ERROR
+
 Created file with length  15
  1
  2
  3
  4
+End of stream: BUF_ERROR
+
 Created file with length  14
  1
  2
  3
  4
+End of stream: BUF_ERROR
+
 Created file with length  13
  1
  2
  3
-OK: End_Error raised
+OK: BUF_ERROR


### PR DESCRIPTION
TC01-031

Raise exception when there was no Z_STREAM_END return code and there is no
input data and there is no output data and Flush = Finish. This way the
error will be detected not only in Read but also in Write and
Generic_Translate routines.
Test improved to detect end-of-stream error even if only one byte removed
from the end of file.