### PR TITLE
Add support for optional values from server's SOAP messages.

### DIFF
--- a/regtests/0103_soapcheck/test.out
+++ b/regtests/0103_soapcheck/test.out
@@ -1,2 +1,2 @@
-Parameter error in Call (R.V expected SOAP.Types.XSD_Integer, found SOAP.TYPES.XSD_STRING)
+Parameter error in Call (Integer expected, found SOAP.TYPES.XSD_STRING)
 Parameter error in Print (Integer expected, found SOAP.TYPES.XSD_STRING)

--- a/regtests/0333_soap_optional_item/aws.ini
+++ b/regtests/0333_soap_optional_item/aws.ini
@@ -1,0 +1,1 @@
+reuse_address true

--- a/regtests/0333_soap_optional_item/optional.adb
+++ b/regtests/0333_soap_optional_item/optional.adb
@@ -1,0 +1,196 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                        Copyright (C) 2021, AdaCore                       --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Calendar;
+with Ada.Integer_Text_IO;
+with Ada.Strings.Unbounded;
+with Ada.Text_IO;
+
+with AWS.Config.Set;
+with AWS.MIME;
+with AWS.Net;
+with AWS.Response;
+with AWS.Server.Status;
+with AWS.Status;
+with AWS.Translator;
+with SOAP.Client;
+with SOAP.Message.Payload;
+with SOAP.Message.Response;
+with SOAP.Message.XML;
+
+with Toptional.Client;
+with Toptional.Server;
+with Toptional.Types;
+
+procedure Optional is
+
+   use Ada;
+   use Ada.Strings.Unbounded;
+   use AWS;
+
+   use Toptional.Types;
+
+   H_Server : Server.HTTP;
+
+   function "+" (Str : String) return Unbounded_String
+     renames To_Unbounded_String;
+
+   package FIO is new Text_IO.Float_IO (Float);
+
+   ------------
+   -- Output --
+   ------------
+
+   procedure Output (S : SOAPStruct_Type) is
+   begin
+      Integer_Text_IO.Put (S.varInt); Text_IO.New_Line;
+      FIO.Put (S.VarFloat, Exp => 0, Aft => 2); Text_IO.New_Line;
+      Text_IO.Put_Line (To_String (S.varString));
+   end Output;
+
+   ---------------------
+   -- T_echoString_CB --
+   ---------------------
+
+   function T_echoString_CB (inputString : String) return String is
+   begin
+      return inputString;
+   end T_echoString_CB;
+
+   function echoString_CB is
+      new Toptional.Server.echoString_CB (T_echoString_CB);
+
+   ------------------
+   -- T_echoString --
+   ------------------
+
+   procedure T_echoString is
+      Res : constant String := Toptional.Client.echoString
+              ("This is the real value for the string!");
+   begin
+      Text_IO.Put_Line ("Echo String");
+
+      Text_IO.Put_Line (Res);
+      Text_IO.New_Line;
+   end T_echoString;
+
+   ---------------------
+   -- T_echoStruct_CB --
+   ---------------------
+
+   function T_echoStruct_CB
+     (inputStruct : SOAPStruct_Type)
+      return echoStruct_Result is
+   begin
+      return inputStruct;
+   end T_echoStruct_CB;
+
+   function echoStruct_CB is
+     new Toptional.Server.echoStruct_CB (T_echoStruct_CB);
+
+   ------------------
+   -- T_echoStruct --
+   ------------------
+
+   procedure T_echoStruct is
+      Struct : constant SOAPStruct_Type := (6, 6.6, +"666");
+      Res    : constant echoStruct_Result :=
+                 Toptional.Client.echoStruct (Struct);
+   begin
+      Text_IO.Put_Line ("Echo Struct");
+      Output (Res);
+      Text_IO.New_Line;
+   end T_echoStruct;
+
+   --------
+   -- CB --
+   --------
+
+   function CB (Request : Status.Data) return Response.Data is
+      SOAPAction : constant String := Status.SOAPAction (Request);
+      P_Str      : aliased constant String := AWS.Status.Payload (Request);
+      Payload    : constant SOAP.Message.Payload.Object :=
+                     SOAP.Message.XML.Load_Payload
+                       (P_Str, Schema => Toptional.Schema);
+      Proc       : constant String :=
+                     SOAP.Message.Payload.Procedure_Name (Payload);
+   begin
+      Text_IO.Put_Line ("@ " & Proc);
+
+      if Proc = "echoString" then
+         return echoString_CB (SOAPAction, Payload, Request);
+
+      elsif Proc = "echoStruct" then
+         return echoStruct_CB (SOAPAction, Payload, Request);
+
+      else
+         return Response.Build
+           (MIME.Text_HTML, "Not a SOAP request, Proc=" & Proc);
+      end if;
+   end CB;
+
+   CNF : Config.Object := Config.Get_Current;
+
+begin
+   Config.Set.Server_Name     (CNF, "WSDL Optional Server");
+   Config.Set.Server_Host     (CNF, "localhost");
+   Config.Set.Server_Port     (CNF, Toptional.Server.Port);
+   Config.Set.Protocol_Family (CNF, "FAMILY_INET");
+
+   Server.Start (H_Server, CB'Unrestricted_Access, CNF);
+
+   if Net.IPv6_Available then
+      Server.Add_Listening
+        (H_Server, "localhost", Toptional.Server.Port, Net.FAMILY_INET6);
+   end if;
+
+   T_echoString;
+   T_echoStruct;
+
+   --  Now check struct with a xsi:nil (optional value)
+
+   declare
+      N   : constant String := String'(1 => ASCII.CR) & ASCII.LF;
+      Mes : aliased constant String :=
+               "<?xml version='1.0' encoding='UTF-8'?>" & N
+               & "<soapenv:Envelope soapenv:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:soap-enc=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">" & N
+               & "<soapenv:Body>" & N
+               & "<ns2:echoStruct xmlns:ns2=""http://nsoptional.org/"""
+               & " xmlns:ns1=""http://nsoptional.org/xsd"">" & N
+               & "<ns1:inputStruct xsi:type=""ns1:SOAPStruct"">"
+               &  "<ns1:varInt xsi:type=""xsd:int"">7</ns1:varInt>"
+               &  "<ns1:varFloat xsi:type=""xsd:float"">7.0</ns1:varFloat>"
+               &  "<ns1:varString xsi:type=""xsd:string"" xsi:nil=""true""/>"
+               & "</ns1:inputStruct>"
+               & "</ns2:echoStruct>" & N
+               & "</soapenv:Body>" & N
+               & "</soapenv:Envelope>";
+      Pl : constant SOAP.Message.Payload.Object :=
+             SOAP.Message.XML.Load_Payload (Mes);
+      R  : constant SOAP.Message.Response.Object'Class :=
+             SOAP.Client.Call
+               (URL        => AWS.Server.Status.Local_URL (H_Server),
+                P          => Pl,
+                SOAPAction => "http://nsoptional.org/");
+   begin
+      Text_IO.Put_Line (SOAP.Message.XML.Image (Pl));
+      Text_IO.Put_Line (SOAP.Message.XML.Image (R));
+   end;
+
+   Server.Shutdown (H_Server);
+end Optional;

--- a/regtests/0333_soap_optional_item/optional.gpr
+++ b/regtests/0333_soap_optional_item/optional.gpr
@@ -1,0 +1,24 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                       Copyright (C) 2021, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with "aws";
+
+project Optional is
+   for Source_Dirs use (".");
+   for Main use ("optional.adb");
+end Optional;

--- a/regtests/0333_soap_optional_item/optional.wsdl
+++ b/regtests/0333_soap_optional_item/optional.wsdl
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<definitions name="toptional"
+             xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:w="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:ns1="http://nsoptional.org/xsd"
+             xmlns:ns2="http://nsoptional.org/"
+             xmlns:tns="http://tempuri.org/4s4c/1/3/wsdl/def/interopLab"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:soap-enc="http://schemas.xmlsoap.org/soap/encoding/"
+             targetNamespace="http://tempuri.org/4s4c/1/3/wsdl/def/interopLab">
+
+	<types>
+	  <schema xmlns="http://www.w3.org/2001/XMLSchema"
+                  targetNamespace="http://nsoptional.org/xsd">
+	    <import namespace="http://schemas.xmlsoap.org/soap/encoding/"/>
+	    <complexType name="SOAPStruct">
+	      <all>
+		<element name="varInt" type="int"/>
+		<element name="varFloat" type="float"/>
+		<element name="varString" type="string"/>
+	      </all>
+	    </complexType>
+          </schema>
+	</types>
+
+	<message name="echoStringRequest">
+	  <part name="inputString" type="xsd:string"/>
+	</message>
+	<message name="echoStringResponse">
+	  <part name="outputString" type="xsd:string"/>
+	</message>
+
+	<message name="echoStructRequest">
+	  <part name="inputStruct" type="ns1:SOAPStruct"/>
+	</message>
+	<message name="echoStructResponse">
+	  <part name="outputStruct" type="ns1:SOAPStruct"/>
+	</message>
+
+	<portType name="interopTestPortType">
+	  <operation name="echoString">
+	    <input message="tns:echoStringRequest"/>
+	    <output message="tns:echoStringResponse"/>
+	  </operation>
+
+	  <operation name="echoStruct">
+	    <input message="tns:echoStructRequest"/>
+	    <output message="tns:echoStructResponse"/>
+	  </operation>
+	</portType>
+
+	<binding name="interopTestBinding" type="tns:interopTestPortType">
+	  <soap:binding style="rpc"
+                        transport="http://schemas.xmlsoap.org/soap/http"/>
+	  <operation name="echoString">
+	    <soap:operation soapAction="http://nsoptional.org/#echoString"/>
+	    <input>
+	      <soap:body use="encoded"
+                         namespace="http://nsoptional.org/"
+                         encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+	    </input>
+	    <output>
+	      <soap:body use="encoded"
+                         namespace="http://nsoptional.org/"
+                         encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+	    </output>
+	  </operation>
+
+	  <operation name="echoStruct">
+	    <soap:operation soapAction="http://nsoptional.org/"/>
+	    <input>
+	      <soap:body use="encoded"
+                         namespace="http://nsoptional.org/"
+                         encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+	    </input>
+	    <output>
+	      <soap:body use="encoded"
+                         namespace="http://nsoptional.org/"
+                         encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+	    </output>
+	  </operation>
+	</binding>
+
+	<service name="toptional">
+	  <port name="interopTestPort" binding="tns:interopTestBinding">
+	    <soap:address location="http://localhost:9113"/>
+	  </port>
+	</service>
+</definitions>

--- a/regtests/0333_soap_optional_item/test.opt
+++ b/regtests/0333_soap_optional_item/test.opt
@@ -1,0 +1,1 @@
+!xmlada DEAD

--- a/regtests/0333_soap_optional_item/test.out
+++ b/regtests/0333_soap_optional_item/test.out
@@ -1,0 +1,38 @@
+@ echoString
+Echo String
+This is the real value for the string!
+
+@ echoStruct
+Echo Struct
+          6
+ 6.60
+666
+
+@ echoStruct
+<?xml version='1.0' encoding='UTF-8'?>
+<soapenv:Envelope soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<soapenv:Body>
+<ns2:echoStruct xmlns:ns2="http://nsoptional.org/"
+ xmlns:ns1="http://nsoptional.org/xsd">
+<ns1:inputStruct xsi:type="ns1:SOAPStruct">
+   <varInt xsi:type="xsd:int">7</varInt>
+   <varFloat xsi:type="xsd:float">7.00000E+00</varFloat>
+   <varString xsi:type="xsd:string" xsi:nil="true"/>
+</ns1:inputStruct>
+</ns2:echoStruct>
+</soapenv:Body>
+</soapenv:Envelope>
+
+<?xml version='1.0' encoding='UTF-8'?>
+<soapenv:Envelope soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soap-enc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<soapenv:Body>
+<ns2:echoStructResponse xmlns:ns2="http://nsoptional.org/"
+ xmlns:ns1="http://nsoptional.org/xsd">
+<ns1:outputStruct xsi:type="ns1:SOAPStruct">
+   <varInt xsi:type="xsd:int">7</varInt>
+   <varFloat xsi:type="xsd:float">7.00000E+00</varFloat>
+   <varString xsi:type="xsd:string"></varString>
+</ns1:outputStruct>
+</ns2:echoStructResponse>
+</soapenv:Body>
+</soapenv:Envelope>

--- a/regtests/0333_soap_optional_item/test.py
+++ b/regtests/0333_soap_optional_item/test.py
@@ -1,0 +1,4 @@
+from test_support import *
+
+exec_cmd('wsdl2aws', ['-q', '-f', '-doc', 'optional.wsdl'])
+build_and_run('optional');

--- a/src/soap/soap-types.adb
+++ b/src/soap/soap-types.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2020, AdaCore                     --
+--                     Copyright (C) 2000-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -85,8 +85,9 @@ package body SOAP.Types is
    generic
       type T is digits <>;
       type XSD_T is new Scalar with private;
-      Inf : T;
-      Name : String;
+      Inf      : T;
+      Name     : String;
+      XML_Type : String;
       with function V (O : XSD_T) return T is <>;
    function F_Get_G (O : Object'Class) return T;
    --  Get a floating point number out of an XSD string representation. This
@@ -301,6 +302,11 @@ package body SOAP.Types is
       if O'Tag = XSD_T'Tag then
          return V (XSD_T (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Type
+      then
+         return 0.0;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             declare
@@ -401,6 +407,11 @@ package body SOAP.Types is
       if O'Tag = Types.XSD_Long'Tag then
          return V (XSD_Long (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Long
+      then
+         return 0;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             return Long'Value (V (XSD_String (O)));
@@ -424,6 +435,11 @@ package body SOAP.Types is
    begin
       if O'Tag = Types.XSD_Integer'Tag then
          return V (XSD_Integer (O));
+
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Int
+      then
+         return 0;
 
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
@@ -449,6 +465,11 @@ package body SOAP.Types is
       if O'Tag = Types.XSD_Short'Tag then
          return V (XSD_Short (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Short
+      then
+         return 0;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             return Short'Value (V (XSD_String (O)));
@@ -473,6 +494,11 @@ package body SOAP.Types is
       if O'Tag = Types.XSD_Byte'Tag then
          return V (XSD_Byte (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Byte
+      then
+         return 0;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             return Byte'Value (V (XSD_String (O)));
@@ -495,10 +521,11 @@ package body SOAP.Types is
       pragma Suppress (Validity_Check);
 
       function Get_Float is new F_Get_G
-        (T     => Float,
-         XSD_T => XSD_Float,
-         Inf   => Float_Infinity,
-         Name  => "Float");
+        (T        => Float,
+         XSD_T    => XSD_Float,
+         Inf      => Float_Infinity,
+         Name     => "Float",
+         XML_Type => XML_Float);
    begin
       return Get_Float (O);
    end Get;
@@ -507,10 +534,11 @@ package body SOAP.Types is
       pragma Suppress (Validity_Check);
 
       function Get_Double is new F_Get_G
-        (T     => Long_Float,
-         XSD_T => XSD_Double,
-         Inf   => Long_Float_Infinity,
-         Name  => "Double");
+        (T        => Long_Float,
+         XSD_T    => XSD_Double,
+         Inf      => Long_Float_Infinity,
+         Name     => "Double",
+         XML_Type => XML_Double);
    begin
       return Get_Double (O);
    end Get;
@@ -522,6 +550,11 @@ package body SOAP.Types is
         or else O'Tag = Types.Untyped.Untyped'Tag
       then
          return V (XSD_String (O));
+
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_String
+      then
+         return "";
 
       elsif O'Tag = Types.XSD_Any_Type'Tag
         and then XSD_Any_Type (O).O.O'Tag = Types.XSD_String'Tag
@@ -541,6 +574,11 @@ package body SOAP.Types is
       then
          return V (XSD_String (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_String
+      then
+         return Null_Unbounded_String;
+
       elsif O'Tag = Types.XSD_Any_Type'Tag
         and then XSD_Any_Type (O).O.O'Tag = Types.XSD_String'Tag
       then
@@ -556,6 +594,11 @@ package body SOAP.Types is
    begin
       if O'Tag = Types.XSD_Boolean'Tag then
          return V (XSD_Boolean (O));
+
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Boolean
+      then
+         return False;
 
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
@@ -581,6 +624,11 @@ package body SOAP.Types is
       if O'Tag = Types.XSD_Time_Instant'Tag then
          return V (XSD_Time_Instant (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Time_Instant
+      then
+         return AWS.Utils.AWS_Epoch;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             return V (Utils.Time_Instant (V (XSD_String (O)), Name (O)));
@@ -604,6 +652,11 @@ package body SOAP.Types is
    begin
       if O'Tag = Types.XSD_Duration'Tag then
          return V (XSD_Duration (O));
+
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Duration
+      then
+         return 0.0;
 
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
@@ -629,6 +682,11 @@ package body SOAP.Types is
       if O'Tag = Types.XSD_Unsigned_Long'Tag then
          return V (XSD_Unsigned_Long (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Unsigned_Long
+      then
+         return 0;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             return Unsigned_Long'Value (V (XSD_String (O)));
@@ -652,6 +710,11 @@ package body SOAP.Types is
    begin
       if O'Tag = Types.XSD_Unsigned_Int'Tag then
          return V (XSD_Unsigned_Int (O));
+
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Unsigned_Int
+      then
+         return 0;
 
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
@@ -677,6 +740,11 @@ package body SOAP.Types is
       if O'Tag = Types.XSD_Unsigned_Short'Tag then
          return V (XSD_Unsigned_Short (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Unsigned_Short
+      then
+         return 0;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             return Unsigned_Short'Value (V (XSD_String (O)));
@@ -701,6 +769,11 @@ package body SOAP.Types is
       if O'Tag = Types.XSD_Unsigned_Byte'Tag then
          return V (XSD_Unsigned_Byte (O));
 
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Unsigned_Byte
+      then
+         return 0;
+
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          begin
             return Unsigned_Byte'Value (V (XSD_String (O)));
@@ -724,6 +797,11 @@ package body SOAP.Types is
    begin
       if O'Tag = Types.SOAP_Base64'Tag then
          return SOAP_Base64 (O);
+
+      elsif O'Tag = Types.XSD_Null'Tag
+        and then O.Type_Name = XML_Base64
+      then
+         return B64 ("", Name (O));
 
       elsif O'Tag = Types.Untyped.Untyped'Tag then
          return B64 (V (XSD_String (O)), Name (O));

--- a/src/soap/soap-utils.adb
+++ b/src/soap/soap-utils.adb
@@ -396,7 +396,12 @@ package body SOAP.Utils is
    function Get (Item : Types.Object'Class) return Character is
       Str : constant String := String'(Types.Get (Item));
    begin
-      return Str (1);
+      --  Str is empty if passed as optional parameter (xsi:nil)
+      if Str'Length = 0 then
+         return ASCII.NUL;
+      else
+         return Str (Str'First);
+      end if;
    end Get;
 
    function Get (Item : Types.Object'Class) return String is

--- a/tools/wsdl2aws-wsdl-types.adb
+++ b/tools/wsdl2aws-wsdl-types.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2015-2018, AdaCore                     --
+--                     Copyright (C) 2015-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -172,16 +172,7 @@ package body WSDL2AWS.WSDL.Types is
       case Def.Mode is
          when WSDL.Types.K_Derived =>
             if Is_Character (Def) then
-               declare
-                  P_Type : constant SOAP.WSDL.Parameter_Type :=
-                             SOAP.WSDL.To_Type (Types.Name (Def.Ref));
-                  I_Type : constant String := SOAP.WSDL.Set_Type (P_Type);
-               begin
-                  return SOAP.WSDL.V_Routine (P_Type, Constrained => True)
-                    & " (" & I_Type & " ("
-                    & Object & "))";
-               end;
-
+               return "SOAP.Utils.Get (" & Object & ")";
             else
                return For_Derived (Def, Object);
             end if;
@@ -206,15 +197,7 @@ package body WSDL2AWS.WSDL.Types is
               & " (SOAP.Types.SOAP_Record (" & Object & "))";
 
          when WSDL.Types.K_Simple =>
-            declare
-               P_Type : constant SOAP.WSDL.Parameter_Type :=
-                          SOAP.WSDL.To_Type (Types.Name (Def.Ref));
-               I_Type : constant String := SOAP.WSDL.Set_Type (P_Type);
-            begin
-               return SOAP.WSDL.V_Routine (P_Type, Constrained => True)
-                 & " (" & I_Type & " ("
-                 & Object & "))";
-            end;
+            return "SOAP.Types.Get (" & Object & ")";
       end case;
    end From_SOAP;
 


### PR DESCRIPTION
When AWS receives a SOAP message with a component xsi:nil="true"
a xsd:null object was created but the deserialization was
raising an exception as not founding the proper SOAP type.

This has been fixed by returning a default value (0, 0.0, False or
empty string) for the corresponding Ada variable/record.

Add a corresponding regression test.

For U122-023.