### PR TITLE
Support content ranges larger than 2 GB

### DIFF
--- a/src/core/aws-client-http_utils.adb
+++ b/src/core/aws-client-http_utils.adb
@@ -405,13 +405,15 @@ package body AWS.Client.HTTP_Utils is
       Append (Result, "bytes=");
 
       if Data_Range.First /= Undefined then
-         Append (Result, Utils.Image (Natural (Data_Range.First)));
+         Append
+           (Result, Utils.Image (Stream_Element_Offset (Data_Range.First)));
       end if;
 
       Append (Result, "-");
 
       if Data_Range.Last /= Undefined then
-         Append (Result, Utils.Image (Natural (Data_Range.Last)));
+         Append
+           (Result, Utils.Image (Stream_Element_Offset (Data_Range.Last)));
       end if;
 
       return To_String (Result);

--- a/src/core/aws-client.ads
+++ b/src/core/aws-client.ads
@@ -103,7 +103,8 @@ package AWS.Client is
    -- Messages --
    --------------
 
-   type Content_Bound is new Integer range -1 .. Integer'Last;
+   type Content_Bound is new
+     Stream_Element_Offset range -1 .. Stream_Element_Offset'Last;
 
    Undefined : constant Content_Bound := -1;
 


### PR DESCRIPTION
Use Ada.Streams.Stream_Element_Offset as base for
AWS.Client.Content_Bound type to increase addressable content ranges.