### PR TITLE
Fix URL decoding.

### DIFF
--- a/src/core/aws-url-set.adb
+++ b/src/core/aws-url-set.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2007-2019, AdaCore                     --
+--                     Copyright (C) 2007-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -206,7 +206,30 @@ package body AWS.URL.Set is
          ---------------------
 
          procedure Parse_Path_File (Start : Positive) is
-            PF : constant String := Decode (URL (Start .. URL'Last));
+
+            function Parameters_Start return Positive;
+            --  Get the start of the parameters if any. We need that as only
+            --  the URL parameters must decode plus characters as spaces.
+
+            ----------------------
+            -- Parameters_Start --
+            ----------------------
+
+            function Parameters_Start return Positive is
+            begin
+               for K in Start .. URL'Last loop
+                  if URL (K) = '?' then
+                     return K;
+                  end if;
+               end loop;
+
+               return URL'Last;
+            end Parameters_Start;
+
+            P  : constant Positive := Parameters_Start;
+            PF : constant String :=
+                   Decode (URL (Start .. P), In_Params => False)
+                   & Decode (URL (P + 1 .. URL'Last), In_Params => True);
             I3 : constant Natural :=
                    Strings.Fixed.Index (PF, "/", Strings.Backward);
          begin

--- a/src/core/aws-url.adb
+++ b/src/core/aws-url.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -103,7 +103,7 @@ package body AWS.URL is
    -- Decode --
    ------------
 
-   function Decode (Str : String) return String is
+   function Decode (Str : String; In_Params : Boolean) return String is
       Res : String (1 .. Str'Length);
       K   : Natural := 0;
       I   : Positive := Str'First;
@@ -123,7 +123,7 @@ package body AWS.URL is
             Res (K) := Character'Val (Utils.Hex_Value (Str (I + 1 .. I + 2)));
             I := I + 2;
 
-         elsif Str (I) = '+' then
+         elsif In_Params and then Str (I) = '+' then
             --  A plus is used for spaces in forms value for example
             Res (K) := ' ';
 
@@ -136,6 +136,11 @@ package body AWS.URL is
       end loop;
 
       return Res (1 .. K);
+   end Decode;
+
+   function Decode (Str : String) return String is
+   begin
+      return Decode (Str, In_Params => True);
    end Decode;
 
    function Decode (Str : Unbounded_String) return Unbounded_String is

--- a/src/core/aws-url.ads
+++ b/src/core/aws-url.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2017, AdaCore                     --
+--                     Copyright (C) 2000-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -247,5 +247,9 @@ private
    Default_Encoding_Set : constant Strings.Maps.Character_Set :=
                             Parameters_Encoding_Set
                             or Strings.Maps.To_Set (";/:$,""{}|\^[]`'");
+
+   function Decode (Str : String; In_Params : Boolean) return String;
+   --  Decode URL Str. In_Params is set to True when decoding the
+   --  parameters URL's fragment.
 
 end AWS.URL;


### PR DESCRIPTION
Remove the translation from plus sign (+) to space. This prevents
downloading any file having a + in its name.

Update the 0023_param2 regression test expected output which was actually
wrong as the name of the parameter was changed from "char+" to "char "
when decoding.

Fixes U326-027.