### PR TITLE
Fix bug in data range handling.

### DIFF
--- a/src/core/aws-server-http_utils.adb
+++ b/src/core/aws-server-http_utils.adb
@@ -2024,6 +2024,7 @@ package body AWS.Server.HTTP_Utils is
          then
             --  Range is wrong, let's send the whole file then
             Send_File;
+            return;
          end if;
 
          if N_Range = 1 then


### PR DESCRIPTION
If the ranges header information is not valid we send the file
as a single chunk but after this action we need to return
immediately and do not want to also handle the ranges data.

Found while working on S507-051.