### PR TITLE
Remove Encode parameter from URL package

### DIFF
--- a/src/core/aws-client-http_utils.adb
+++ b/src/core/aws-client-http_utils.adb
@@ -743,7 +743,7 @@ package body AWS.Client.HTTP_Utils is
             Send_Header
               (Sock.all,
                Method & ' '
-               & AWS.URL.Pathname_And_Parameters (Connection.Host_URL, False)
+               & AWS.URL.Pathname_And_Parameters (Connection.Host_URL)
                & ' ' & HTTP_Version);
 
          else

--- a/src/core/aws-url.adb
+++ b/src/core/aws-url.adb
@@ -246,15 +246,14 @@ package body AWS.URL is
    ----------
 
    function Host
-     (URL : Object; IPv6_Brackets : Boolean := False) return String is
+     (URL : Object; IPv6_Brackets : Boolean := False) return String
+   is
+      Result : constant String := To_String (URL.Host);
    begin
-      if IPv6_Brackets
-        and then Ada.Strings.Unbounded.Index (URL.Host, ":") > 0
-      then
-         return '[' & To_String (URL.Host) & ']';
-      else
-         return To_String (URL.Host);
-      end if;
+      return (if IPv6_Brackets
+                and then Ada.Strings.Fixed.Index (Result, ":") > 0
+              then '[' & Result & ']'
+              else Result);
    end Host;
 
    --------------
@@ -390,10 +389,9 @@ package body AWS.URL is
 
    function Port_Not_Default (URL : Object) return String is
    begin
-      if (URL.Port = Default_HTTP_Port and then URL.Protocol = HTTP)
-        or else (URL.Port = Default_HTTP_Port and then URL.Protocol = WS)
-        or else (URL.Port = Default_HTTPS_Port and then URL.Protocol = HTTPS)
-        or else (URL.Port = Default_HTTPS_Port and then URL.Protocol = WSS)
+      if (URL.Port = Default_HTTP_Port and then URL.Protocol in HTTP | WS)
+        or else (URL.Port = Default_HTTPS_Port
+                 and then URL.Protocol in HTTPS | WSS)
         or else (URL.Port = Default_FTP_Port and then URL.Protocol = FTP)
       then
          return "";

--- a/src/core/aws-url.adb
+++ b/src/core/aws-url.adb
@@ -55,17 +55,9 @@ package body AWS.URL is
    -- Abs_Path --
    --------------
 
-   function Abs_Path
-     (URL    : Object;
-      Encode : Boolean := False) return String
-   is
-      Result : constant String := To_String (URL.Path & URL.File);
+   function Abs_Path (URL : Object) return String is
    begin
-      if Encode then
-         return AWS.URL.Encode (Result);
-      else
-         return Result;
-      end if;
+      return To_String (URL.Path & URL.File);
    end Abs_Path;
 
    ----------------------
@@ -221,15 +213,9 @@ package body AWS.URL is
    -- File --
    ----------
 
-   function File
-     (URL    : Object;
-      Encode : Boolean := False) return String is
+   function File (URL : Object) return String is
    begin
-      if Encode then
-         return AWS.URL.Encode (To_String (URL.File));
-      else
-         return To_String (URL.File);
-      end if;
+      return To_String (URL.File);
    end File;
 
    --------------
@@ -299,23 +285,9 @@ package body AWS.URL is
       return URL.Parameters;
    end Parameters;
 
-   function Parameters
-     (URL    : Object;
-      Encode : Boolean := False) return String
-   is
-      P : constant String := AWS.Parameters.URI_Format (URL.Parameters);
+   function Parameters (URL : Object) return String is
    begin
-      if P'Length = 0 then
-         --  No parameter, we do not want the leading '?'
-         return "";
-
-      else
-         if Encode then
-            return '?' & AWS.URL.Encode (P (P'First + 1 .. P'Last));
-         else
-            return '?' & P (P'First + 1 .. P'Last);
-         end if;
-      end if;
+      return AWS.Parameters.URI_Format (URL.Parameters);
    end Parameters;
 
    -----------
@@ -347,26 +319,18 @@ package body AWS.URL is
    -- Path --
    ----------
 
-   function Path
-     (URL    : Object;
-      Encode : Boolean := False) return String is
+   function Path (URL : Object) return String is
    begin
-      if Encode then
-         return AWS.URL.Encode (To_String (URL.Path));
-      else
-         return To_String (URL.Path);
-      end if;
+      return To_String (URL.Path);
    end Path;
 
    -----------------------------
    -- Pathname_And_Parameters --
    -----------------------------
 
-   function Pathname_And_Parameters
-     (URL    : Object;
-      Encode : Boolean := False) return String is
+   function Pathname_And_Parameters (URL : Object) return String is
    begin
-      return Pathname (URL, Encode) & Parameters (URL, Encode);
+      return Pathname (URL) & Parameters (URL);
    end Pathname_And_Parameters;
 
    ----------
@@ -413,11 +377,8 @@ package body AWS.URL is
    -- Query --
    -----------
 
-   function Query
-     (URL    : Object;
-      Encode : Boolean := False) return String
-   is
-      P : constant String := Parameters (URL, Encode);
+   function Query (URL : Object) return String is
+      P : constant String := Parameters (URL);
    begin
       return P (P'First + 1 .. P'Last);
    end Query;

--- a/src/core/aws-url.ads
+++ b/src/core/aws-url.ads
@@ -104,15 +104,11 @@ package AWS.URL is
    --  Returns the port image (preceded by character ':') if it is not the
    --  default port. Returns the empty string otherwise.
 
-   function Abs_Path
-     (URL    : Object;
-      Encode : Boolean := False) return String;
+   function Abs_Path (URL : Object) return String;
    --  Returns the absolute path. This is the complete resource reference
    --  without the query part.
 
-   function Query
-     (URL    : Object;
-      Encode : Boolean := False) return String;
+   function Query (URL : Object) return String;
    --  Returns the Query part of the URL or the empty string if none was
    --  specified. Note that character '?' is not part of the Query and is
    --  therefore not returned.
@@ -136,29 +132,23 @@ package AWS.URL is
    function Security (URL : Object) return Boolean;
    --  Returns True if it is a Secure HTTP (HTTPS) URL
 
-   function Path (URL : Object; Encode : Boolean := False) return String;
+   function Path (URL : Object) return String;
    --  Returns the Path (including the leading slash). If Encode is True then
    --  the URL will be encoded using the Encode routine.
 
-   function File (URL : Object; Encode : Boolean := False) return String;
+   function File (URL : Object) return String;
    --  Returns the File. If Encode is True then the URL will be encoded using
    --  the Encode routine. Not that by File here we mean the latest part of
    --  the URL, it could be a real file or a diretory into the filesystem.
    --  Parent and current directories are part of the path.
 
-   function Parameters
-     (URL    : Object;
-      Encode : Boolean := False) return String;
+   function Parameters (URL : Object) return String;
    --  Returns the Parameters (including the starting ? character). If Encode
    --  is True then the URL will be encoded using the Encode routine.
 
-   function Pathname
-     (URL    : Object;
-      Encode : Boolean := False) return String renames Abs_Path;
+   function Pathname (URL : Object) return String renames Abs_Path;
 
-   function Pathname_And_Parameters
-     (URL    : Object;
-      Encode : Boolean := False) return String;
+   function Pathname_And_Parameters (URL : Object) return String;
    --  Returns the pathname and the parameters. This is equivalent to:
    --  Pathname & Parameters.
 


### PR DESCRIPTION
It is not used in AWS internally and can be easy replaced by Encode call
from the same package.