### PR TITLE
Common output for RedHat ES v7 32bit

### DIFF
--- a/regtests/0245_errcon/test.opt
+++ b/regtests/0245_errcon/test.opt
@@ -15,7 +15,6 @@ darwin,gnat OUT test-darwin.out
 freebsd,!ipv4 OUT test-freebsd-ipv6.out
 freebsd,ipv4 OUT test-freebsd-ipv4.out
 vxworks6,!vxworks6-6.6 OUT test-vxworks.out
-linux-rhES7,x86 OUT test-rhES7-x86.out
 linux-rhES8,x86 OUT test-rhES7-x86.out
 gnat OUT test.out
 ipv6 OUT test-ipv6.out


### PR DESCRIPTION
U711-002

0245_errcon test output became common for the RedHat ES version 7 32bit.