### PR TITLE
Fix HPACK encoder

### DIFF
--- a/regtests/0341_hpack/main.adb
+++ b/regtests/0341_hpack/main.adb
@@ -1,0 +1,103 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                      Copyright (C) 2021, AdaCore                         --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Streams;           use Ada.Streams;
+with Ada.Text_IO;           use Ada.Text_IO;
+with AWS.Headers;
+with AWS.HTTP2.Connection;
+with AWS.HTTP2.HPACK.Table; use AWS.HTTP2.HPACK;
+
+procedure Main is
+   Settings : aliased AWS.HTTP2.Connection.Object;
+   Tab_Enc, Tab_Dec : aliased Table.Object;
+
+   H : AWS.Headers.List;
+
+   procedure Test is
+      Binary : constant Stream_Element_Array :=
+                 Encode (Tab_Enc'Access, Settings'Access, H);
+      Index : Stream_Element_Offset := Binary'First;
+
+      function End_Of_Stream return Boolean is (Index > Binary'Last);
+
+      function Next_Byte return Stream_Element is
+      begin
+         return Result : constant Stream_Element := Binary (Index) do
+            Index := Index + 1;
+         end return;
+      end Next_Byte;
+
+      function Decode is new AWS.HTTP2.HPACK.Decode (End_Of_Stream, Next_Byte);
+
+      procedure Print (It : AWS.Headers.List) is
+      begin
+         Put_Line ("#" & It.Count'Img & It.Length'Img);
+         for J in 1 .. It.Count loop
+            Put_Line (It.Get_Line (J));
+         end loop;
+      end Print;
+
+      M : AWS.Headers.List := Decode (Tab_Dec'Access, Settings'Access);
+      use type AWS.Headers.List, AWS.HTTP2.HPACK.Table.Object;
+
+   begin
+      if M /= H then
+         Ada.Text_IO.Put_Line ("Headers differ");
+         Print (H);
+         Print (M);
+      end if;
+
+      if Tab_Enc /= Tab_Dec then
+         Put_Line ("--  Enc");
+         Tab_Enc.Dump;
+         Put_Line ("--  Dec");
+         Tab_Dec.Dump;
+      end if;
+   end Test;
+
+   Size : Positive;
+
+begin
+   H.Add (":method", "GET");
+   H.Add (":path", "/readme.txt");
+   H.Add (":scheme", "https");
+   H.Add (":authority", "localhost:4433");
+   H.Add ("user-agent", "curl/7.68.0");
+   H.Add ("accept", "*/*");
+   H.Add ("x-custom", "custom-value");
+   H.Add ("x-another-one", "another-value");
+   H.Add ("x-one-more", "more-value");
+   H.Add ("x-last-one", "last-value");
+
+   Test;
+   Test;
+
+   for J in -1000 .. -1 loop
+      Size := Tab_Dec.Size;
+
+      H.Add ("x-header" & Integer'Image (J - 1), 'v' & J'Img);
+      H.Add ("x-header" & Integer'Image (J - 1), 'v' & Integer'Image (J - 1));
+      H.Add ("x-header" & J'Img, 'v' & J'Img);
+
+      Test;
+
+      --  Exit after test of table truncation to the same size
+
+      exit when Size = Tab_Dec.Size;
+   end loop;
+end Main;

--- a/regtests/0341_hpack/main.gpr
+++ b/regtests/0341_hpack/main.gpr
@@ -1,0 +1,25 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                      Copyright (C) 2021, AdaCore                         --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with "aws.gpr";
+
+project Main is
+    for Object_Dir use "obj";
+    for Exec_Dir use ".";
+    for Main use ("main.adb");
+end Main;

--- a/regtests/0341_hpack/test.py
+++ b/regtests/0341_hpack/test.py
@@ -1,0 +1,3 @@
+from test_support import build_and_run
+
+build_and_run('main');

--- a/src/http2/aws-http2-hpack-table.ads
+++ b/src/http2/aws-http2-hpack-table.ads
@@ -55,12 +55,18 @@ package AWS.HTTP2.HPACK.Table is
    --  Get Name & Value pair at the given index in the table
 
    function Get_Name_Value_Index
-     (Self  : Object;
-      Name  : String;
-      Value : String := "";
-      Both  : out Boolean) return Positive;
-   --  Get the index of the Name (and Value if specificed). Both is set to true
-   --  if the pair is found and False if only the Name has been found.
+     (Self     : in out Object;
+      Settings : not null access HTTP2.Connection.Object;
+      Name     : String;
+      Value    : String := "";
+      Both     : out Boolean) return Natural;
+   --  Get the index of the Name (and Value if specificed).
+   --  Returns 0 if not found and adds Name to the internal table to search
+   --  later. Both is set to true if the pair is found and False if only the
+   --  Name has been found.
+
+   function Size (Self : Object) return Natural;
+   --  Returns size of the table in bytes
 
    procedure Dump (Self : Object);
    --  Dump table content for debug
@@ -72,13 +78,8 @@ private
    package Index_NV is
      new Containers.Indefinite_Vectors (Positive, Name_Value);
 
-   type Ids is record
-      Index : Positive; -- index in vector above
-      Rank  : Positive; -- actual rank number for the entry
-   end record;
-
    package NV_Index is
-     new Containers.Indefinite_Ordered_Maps (String, Ids);
+     new Containers.Indefinite_Ordered_Maps (String, Positive);
 
    type Static_Table is record
       T_IN : Index_NV.Vector;
@@ -96,5 +97,8 @@ private
    type Object is tagged record
       Dynamic : Dynamic_Table;
    end record;
+
+   function Size (Self : Object) return Natural is
+     (Self.Dynamic.Size);
 
 end AWS.HTTP2.HPACK.Table;

--- a/src/http2/aws-http2-hpack.adb
+++ b/src/http2/aws-http2-hpack.adb
@@ -424,14 +424,22 @@ package body AWS.HTTP2.HPACK is
       ----------
 
       procedure Send (Str : String) is
+         HE : constant Stream_Element_Array := Huffman.Encode (Str);
       begin
-         --  ??? Str is never huffman encoded
+         if HE'Length < Str'Length then
+            Send_Integer (I => HE'Length, Prefix => 2#1000_0000#, N => 7);
 
-         Send_Integer (I => Str'Length, Prefix => 0, N => 7);
+            for E of HE loop
+               Append (E);
+            end loop;
 
-         for K in Str'Range loop
-            Append (Stream_Element (Character'Pos (Str (K))));
-         end loop;
+         else
+            Send_Integer (I => Str'Length, Prefix => 0, N => 7);
+
+            for C of Str loop
+               Append (Character'Pos (C));
+            end loop;
+         end if;
       end Send;
 
       ------------------


### PR DESCRIPTION
HPACK Encoder was not able to use dynamic tables.
Optimize HPACK Decoder.
No need Rank and Index together. For the Static table we need Index.
For the Dynamix table we need Rank only.

Part of S507-051.