### PR TITLE
Refactor and optimize resources API

### DIFF
--- a/config/src/templates_parser-input__aws.adb
+++ b/config/src/templates_parser-input__aws.adb
@@ -116,9 +116,12 @@ package body Templates_Parser.Input is
       File := new File_Record;
       Open (File.all, Name, Form);
    exception
-      when IO_Exceptions.Name_Error =>
-         Free (File);
-         raise Name_Error with "File '" & Name & "' not found.";
+      when others =>
+         if File /= null then
+            Close (File);
+         end if;
+
+         raise;
    end Open;
 
 end Templates_Parser.Input;

--- a/demos/wps/wps.adb
+++ b/demos/wps/wps.adb
@@ -35,7 +35,8 @@ procedure WPS is
 begin
    Text_IO.Put_Line ("AWS " & AWS.Version);
    Text_IO.Put_Line
-     ("Server port:" & Integer'Image (AWS.Config.Server_Port (Config)));
+     ("Server http" & (if AWS.Config.Security (Config) then "s" else "")
+      & " port:" & Integer'Image (AWS.Config.Server_Port (Config)));
    Text_IO.Put_Line ("Kill me when you want me to stop or press Q...");
 
    if AWS.Config.Directory_Browser_Page (Config) /= "" then

--- a/src/core/aws-resources-embedded.ads
+++ b/src/core/aws-resources-embedded.ads
@@ -75,4 +75,14 @@ package AWS.Resources.Embedded is
    --  embedded resource registered as compressed. If a file is already
    --  registered for this name, Content replace the previous one.
 
+   function Get_Buffer
+     (Name : String; GZip : in out Boolean) return Buffer_Access;
+   --  Get registered embedded resource buffer access by Name. Returns null if
+   --  not found. GZip "in" value defines what resource version is preferred,
+   --  compressed or plain. GZip "out" value defines what resource version was
+   --  found, compressed or plain. In the spetial case when Name has .gz"
+   --  suffix already, GZip "in" value is ignored, routine looks only for Name
+   --  without duplicated additional suffix, and GZip "out" value became False
+   --  if resource was found.
+
 end AWS.Resources.Embedded;

--- a/src/core/aws-resources-streams-disk.ads
+++ b/src/core/aws-resources-streams-disk.ads
@@ -66,16 +66,9 @@ private
 
    use Ada.Strings.Unbounded;
 
-   Buffer_Size : constant := 8_192;
-
    type Stream_Type is new Streams.Stream_Type with record
-      File    : Stream_IO.File_Type;
-      Stream  : Stream_IO.Stream_Access;
-      --  Below are data for buffered access to the file
-      Buffer  : Stream_Element_Array (1 .. Buffer_Size);
-      Current : Stream_Element_Offset := 1;
-      Last    : Stream_Element_Offset := 0;
-      Name    : Unbounded_String;
+      File : Stream_IO.File_Type;
+      Name : Unbounded_String;
    end record;
 
 end AWS.Resources.Streams.Disk;

--- a/src/core/aws-resources-streams.ads
+++ b/src/core/aws-resources-streams.ads
@@ -66,7 +66,18 @@ package AWS.Resources.Streams is
    procedure Create
      (Resource : out File_Type;
       Stream   : Stream_Access) with Inline;
-   --  Create a resource file from user defined stream
+   --  Create a resource file from stream
+
+   function Open
+     (Name : String;
+      Form : String         := "";
+      GZip : in out Boolean;
+      Once : Boolean        := False) return Stream_Access;
+   --  Create stream by name either from embedded resource or from file.
+   --  Returns null if neither embedded resource nore file can be found with
+   --  such Name. GZip parameter has the same meaning like in
+   --  AWS.Resources.Open routine.
+   --  If Once is True than remove file on Close the stream.
 
 private
 

--- a/src/core/aws-resources.ads
+++ b/src/core/aws-resources.ads
@@ -177,4 +177,20 @@ private
    procedure Unchecked_Free is
       new Ada.Unchecked_Deallocation (Resources.File_Tagged'Class, File_Type);
 
+   function Check_Name
+     (Name  : String;
+      Check : not null access function (Name : String) return Boolean;
+      GZip  : in out Boolean) return String;
+   --  Checks for existence of Name and/or Name & ".gz" resources with provided
+   --  Check routine and returns Name or Name & ".gz" depend on resource
+   --  existence and user preferences expressed in GZip "in" value.
+   --  Empty return value mean that both resources Name and Name & ".gz" does
+   --  not found. If Name already has ".gz" suffix then Name & ".gz" does not
+   --  check for existence.
+   --  GZip "in" True value mean that caller prefer to get Name & ".gz"
+   --  recource instead of Name. GZip "in" False value mean that caller prefer
+   --  to get Name recource instead of Name & ".gz".
+   --  GZip "out" True value mean that Name & ".gz" resource found.
+   --  GZip "out" False value mean that Name resource found.
+
 end AWS.Resources;

--- a/src/core/aws-response.ads
+++ b/src/core/aws-response.ads
@@ -405,6 +405,15 @@ package AWS.Response is
    --  if file or embedded resource is in the GZip format this routine would
    --  define Content-Encoding header field value.
 
+   function Create_Stream
+     (D    : in out Data;
+      GZip : Boolean) return AWS.Resources.Streams.Stream_Access;
+   --  Creates the stream access for the data to be sent to the client.
+   --  The resource should be closed and freed after use.
+   --  GZip is true when the http client support GZip decoding,
+   --  if file or embedded resource is in the GZip format this routine would
+   --  define Content-Encoding header field value.
+
    function Close_Resource (D : Data) return Boolean;
    --  Returns True if the resource stream must be closed
 

--- a/src/core/aws-server-protocol_handler_v2.adb
+++ b/src/core/aws-server-protocol_handler_v2.adb
@@ -389,7 +389,7 @@ is
          Ctx.Status := LA.Stat;
          Ctx.Response := R;
 
-         return HTTP2.Message.Create (R, Stream.Identifier);
+         return HTTP2.Message.Create (R, LA.Stat, Stream.Identifier);
       end;
    end Handle_Message;
 
@@ -428,6 +428,10 @@ is
                Header : constant String := Headers.Get_Name (K);
                Value  : constant String := Headers.Get_Value (K);
             begin
+               if HTTP2.Debug then
+                  Ada.Text_IO.Put_Line ("#hg " & Header & ' ' & Value);
+               end if;
+
                if Header'Length > 1 and then Header (Header'First) = ':' then
                   --  Pseudo header
 
@@ -735,9 +739,10 @@ begin
                else
                   exit when Frame.Kind = K_Data
                     and then
-                      (Settings.Flow_Control_Window < Integer (Frame.Length)
-                       or else S (Stream_Id).Flow_Control_Window <
-                             Integer (Frame.Length));
+                      Integer'Min
+                        (Settings.Flow_Control_Window,
+                         S (Stream_Id).Flow_Control_Window)
+                      < Integer (Frame.Length);
 
                   S (Stream_Id).Send_Frame (Frame);
 

--- a/src/http2/aws-http2-message.adb
+++ b/src/http2/aws-http2-message.adb
@@ -77,34 +77,6 @@ package body AWS.HTTP2.Message is
       end return;
    end Create;
 
-   function Create
-     (Headers   : AWS.Headers.List;
-      Payload   : Unbounded_String;
-      Stream_Id : HTTP2.Stream_Id) return Object is
-   begin
-      return O : Object (Response.Message) do
-         O.Stream_Id := Stream_Id;
-         O.Headers   := Headers;
-         O.Payload   := Payload;
-         O.Sent      := 0;
-         O.Length    := Utils.File_Size_Type (Length (Payload));
-      end return;
-   end Create;
-
-   function Create
-     (Headers   : AWS.Headers.List;
-      Filename  : String;
-      Stream_Id : HTTP2.Stream_Id) return Object is
-   begin
-      return O : Object (Response.File) do
-         O.Stream_Id := Stream_Id;
-         O.Headers   := Headers;
-         O.Filename  := To_Unbounded_String (Filename);
-         O.Sent      := 0;
-         O.Length    := Utils.File_Size (Filename);
-      end return;
-   end Create;
-
    ---------------
    -- To_Frames --
    ---------------

--- a/src/http2/aws-http2-message.ads
+++ b/src/http2/aws-http2-message.ads
@@ -54,24 +54,6 @@ package AWS.HTTP2.Message is
       Stream_Id : HTTP2.Stream_Id) return Object
      with Post => Create'Result.Is_Defined;
 
-   function Create
-     (Headers   : AWS.Headers.List;
-      Payload   : Unbounded_String;
-      Stream_Id : HTTP2.Stream_Id)
-      return Object
-     with Pre  => Length (Payload) > 0 or else not Headers.Is_Empty,
-          Post => Create'Result.Is_Defined;
-   --  Create a message based on the given headers and payload
-
-   function Create
-     (Headers  : AWS.Headers.List;
-      Filename : String;
-      Stream_Id : HTTP2.Stream_Id)
-      return Object
-     with Pre  => not Headers.Is_Empty,
-          Post => Create'Result.Is_Defined;
-   --  Create a message based on the given headers and payload
-
    function Stream_Id (Self : Object) return HTTP2.Stream_Id
      with Pre => Self.Is_Defined;
 


### PR DESCRIPTION
To be able to use in HTTP2.
Remove unused AWS.HTTP2.Message routines.

Part of S507-051.