### PR TITLE
Ensure input buffer for ZLib stream is bigger than output one.

### DIFF
--- a/include/zlib-streams.adb
+++ b/include/zlib-streams.adb
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------
 --  ZLib for Ada thick binding.                               --
 --                                                            --
---  Copyright (C) 2002-2019, Dmitriy Anisimkov                --
+--  Copyright (C) 2002-2021, Dmitriy Anisimkov                --
 --                                                            --
 --  Open source license information is in the zlib.ads file.  --
 ----------------------------------------------------------------
@@ -41,11 +41,11 @@ package body ZLib.Streams is
       Mode              : in     Stream_Mode;
       Back              : in     Stream_Access;
       Back_Compressed   : in     Boolean;
-      Level             : in     Compression_Level := Default_Compression;
-      Strategy          : in     Strategy_Type     := Default_Strategy;
-      Header            : in     Header_Type       := Default;
-      Read_Buffer_Size  : in     Stream_Element_Offset := Default_Buffer_Size;
-      Write_Buffer_Size : in     Stream_Element_Offset := Default_Buffer_Size)
+      Level             : in     Compression_Level     := Default_Compression;
+      Strategy          : in     Strategy_Type         := Default_Strategy;
+      Header            : in     Header_Type           := Default;
+      Read_Buffer_Size  : in     Stream_Element_Offset := Default_RBuffer_Size;
+      Write_Buffer_Size : in     Stream_Element_Offset := Default_WBuffer_Size)
    is
       subtype Buffer_Subtype is Stream_Element_Array (1 .. Read_Buffer_Size);
 

--- a/include/zlib-streams.ads
+++ b/include/zlib-streams.ads
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------
 --  ZLib for Ada thick binding.                               --
 --                                                            --
---  Copyright (C) 2002-2019, Dmitriy Anisimkov                --
+--  Copyright (C) 2002-2021, Dmitriy Anisimkov                --
 --                                                            --
 --  Open source license information is in the zlib.ads file.  --
 ----------------------------------------------------------------
@@ -56,8 +56,8 @@ package ZLib.Streams is
       Level             : in     Compression_Level     := Default_Compression;
       Strategy          : in     Strategy_Type         := Default_Strategy;
       Header            : in     Header_Type           := Default;
-      Read_Buffer_Size  : in     Stream_Element_Offset := Default_Buffer_Size;
-      Write_Buffer_Size : in     Stream_Element_Offset := Default_Buffer_Size);
+      Read_Buffer_Size  : in     Stream_Element_Offset := Default_RBuffer_Size;
+      Write_Buffer_Size : in     Stream_Element_Offset := Default_WBuffer_Size);
    --  Create the Comression/Decompression stream.
    --  If mode is In_Stream then Write operation is disabled.
    --  If mode is Out_Stream then Read operation is disabled.

--- a/include/zlib.adb
+++ b/include/zlib.adb
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------
 --  ZLib for Ada thick binding.                               --
 --                                                            --
---  Copyright (C) 2002-2020, Dmitriy Anisimkov                --
+--  Copyright (C) 2002-2021, Dmitriy Anisimkov                --
 --                                                            --
 --  Open source license information is in the zlib.ads file.  --
 ----------------------------------------------------------------
@@ -240,8 +240,8 @@ package body ZLib is
 
    procedure Generic_Translate
      (Filter          : in out ZLib.Filter_Type;
-      In_Buffer_Size  : in     Integer := Default_Buffer_Size;
-      Out_Buffer_Size : in     Integer := Default_Buffer_Size)
+      In_Buffer_Size  : in     Integer := Default_RBuffer_Size;
+      Out_Buffer_Size : in     Integer := Default_WBuffer_Size)
    is
       In_Buffer  : Stream_Element_Array
                      (1 .. Stream_Element_Offset (In_Buffer_Size));

--- a/include/zlib.ads
+++ b/include/zlib.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                       ZLib for Ada thick binding.                        --
 --                                                                          --
---                Copyright (C) 2002-2019, Dmitriy Anisimkov                --
+--                Copyright (C) 2002-2021, Dmitriy Anisimkov                --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -125,7 +125,8 @@ package ZLib is
    RLE              : constant Strategy_Type;
    Default_Strategy : constant Strategy_Type;
 
-   Default_Buffer_Size : constant := 4096;
+   Default_RBuffer_Size : constant := 4096 + 5;
+   Default_WBuffer_Size : constant := 4096;
 
    type Filter_Type is tagged limited private;
    --  The filter is for compression and for decompression.
@@ -183,8 +184,8 @@ package ZLib is
         (Item : in Stream_Element_Array);
    procedure Generic_Translate
      (Filter          : in out Filter_Type;
-      In_Buffer_Size  : in     Integer := Default_Buffer_Size;
-      Out_Buffer_Size : in     Integer := Default_Buffer_Size);
+      In_Buffer_Size  : in     Integer := Default_RBuffer_Size;
+      Out_Buffer_Size : in     Integer := Default_WBuffer_Size);
    --  Compress/decompress data fetch from Data_In routine and pass the result
    --  to the Data_Out routine. User should provide Data_In and Data_Out
    --  for compression/decompression data flow.
@@ -240,7 +241,7 @@ package ZLib is
       --  User should provide this routine to accept
       --  compressed/decompressed data.
 
-      Buffer_Size : in Stream_Element_Offset := Default_Buffer_Size;
+      Buffer_Size : in Stream_Element_Offset := Default_WBuffer_Size;
       --  Buffer size for Write user routine
 
    procedure Write


### PR DESCRIPTION
This force a one byte ahead read of the stream and properly detect
the end of compressed stream which can possibly contains padding
at the end.

For U727-039.