### PR TITLE
Detect end of ZLib stream better

### DIFF
--- a/include/zlib-streams.ads
+++ b/include/zlib-streams.ads
@@ -91,6 +91,11 @@ private
       --  We need to have this buffer in the record because not all read data
       --  from back stream could be processed during the read operation.
 
+      Ahead_Last : Stream_Element_Offset;
+      --  Sometimes the decompressed data is over but the gzip footer still was
+      --  not read from back stream. We should try to read ahead in case we are
+      --  suspect this to detect end of stream proper.
+
       Buffer_Size : Stream_Element_Offset;
       --  Buffer size for write operation.
       --  We do not need to have this buffer in the record because all data
@@ -102,6 +107,8 @@ private
    end record;
 
    function End_Of_Stream (Stream : in Stream_Type) return Boolean is
-     (Stream_End (Stream.Reader));
+     (Stream_End (Stream.Reader)
+      and then Stream.Rest_First > Stream.Rest_Last
+      and then Stream.Rest_Last >= Stream.Ahead_Last);
 
 end ZLib.Streams;

--- a/include/zlib.ads
+++ b/include/zlib.ads
@@ -263,8 +263,10 @@ package ZLib is
 
       Rest_First, Rest_Last : in out Stream_Element_Offset;
       --  Rest_First have to be initialized to Buffer'Last + 1
-      --  Rest_Last have to be initialized to Buffer'Last
-      --  before usage.
+      --  Rest_Last have to be initialized to Buffer'Last before usage.
+      --  When no more data provided with first generic parameter procedure
+      --  Read then the Read_First became Buffer'First and the Read_Last became
+      --  Buffer'First - 1.
 
       Allow_Read_Some : in Boolean := False;
       --  Is it allowed to return Last < Item'Last before end of data

--- a/regtests/0330_zlib_stream_end/test.out
+++ b/regtests/0330_zlib_stream_end/test.out
@@ -1,44 +1,19 @@
  1
  2
  3
- 4
+ 4 last
  0 0
 Created file with length  18
  1
  2
  3
- 4
-End of stream: BUF_ERROR
-
-Created file with length  17
+OK: BUF_ERROR
  1
  2
  3
- 4
-End of stream: BUF_ERROR
-
-Created file with length  16
- 1
- 2
- 3
- 4
-End of stream: BUF_ERROR
-
-Created file with length  15
- 1
- 2
- 3
- 4
-End of stream: BUF_ERROR
-
-Created file with length  14
- 1
- 2
- 3
- 4
-End of stream: BUF_ERROR
-
-Created file with length  13
+ 4 last
+ 0 0
+Created file with length  30
  1
  2
  3

--- a/regtests/0342_zlib_eof/default.gpr
+++ b/regtests/0342_zlib_eof/default.gpr
@@ -1,0 +1,7 @@
+with "aws";
+
+project Default is
+
+   for Main use ("zeof.adb");
+
+end Default;

--- a/regtests/0342_zlib_eof/test.py
+++ b/regtests/0342_zlib_eof/test.py
@@ -1,0 +1,8 @@
+from test_support import build, exec_cmd, run
+
+
+build('default');
+exec_cmd("gzip", ["-k", "zeof.adb"])
+exec_cmd("gzip", ["-k", "zeof.ali"])
+run("zeof", ["zeof.adb.gz"])
+run("zeof", ["zeof.ali.gz"])

--- a/regtests/0342_zlib_eof/zeof.adb
+++ b/regtests/0342_zlib_eof/zeof.adb
@@ -1,0 +1,140 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                     Copyright (C) 2007-2012, AdaCore                     --
+--                                                                          --
+--  This library is free software;  you can redistribute it and/or modify   --
+--  it under terms of the  GNU General Public License  as published by the  --
+--  Free Software  Foundation;  either version 3,  or (at your  option) any --
+--  later version. This library is distributed in the hope that it will be  --
+--  useful, but WITHOUT ANY WARRANTY;  without even the implied warranty of --
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    --
+--                                                                          --
+--  As a special exception under Section 7 of GPL version 3, you are        --
+--  granted additional permissions described in the GCC Runtime Library     --
+--  Exception, version 3.1, as published by the Free Software Foundation.   --
+--                                                                          --
+--  You should have received a copy of the GNU General Public License and   --
+--  a copy of the GCC Runtime Library Exception along with this program;    --
+--  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see   --
+--  <http://www.gnu.org/licenses/>.                                         --
+--                                                                          --
+--  As a special exception, if other files instantiate generics from this   --
+--  unit, or you link this unit with other files to produce an executable,  --
+--  this  unit  does not  by itself cause  the resulting executable to be   --
+--  covered by the GNU General Public License. This exception does not      --
+--  however invalidate any other reasons why the executable file  might be  --
+--  covered by the  GNU Public License.                                     --
+------------------------------------------------------------------------------
+
+with Ada.Command_Line;
+with Ada.Streams.Stream_IO;
+with Ada.Text_IO;
+
+with AWS.Containers.Memory_Streams;
+
+with System;
+with ZLib.Streams;
+
+procedure Zeof is
+   use Ada;
+   use Ada.Streams;
+   use ZLib;
+
+   package MS renames AWS.Containers.Memory_Streams;
+
+   F  : Stream_IO.File_Type;
+   ZS : ZLib.Streams.Stream_Type;
+   SA : Stream_IO.Stream_Access;
+
+   GZip_Size : Stream_Element_Offset := 0;
+   Collector : MS.Stream_Type;
+   Plain     : access Stream_Element_Array;
+   Last      : Stream_Element_Offset;
+
+begin
+   Stream_IO.Open (F, Stream_IO.In_File, Ada.Command_Line.Argument (1));
+
+   SA := Stream_IO.Stream (F);
+
+   GZip_Size := Stream_Element_Offset (Stream_IO.Size (F));
+
+   for Buffer_Size in reverse GZip_Size - 20 .. GZip_Size + 1 loop
+      ZLib.Streams.Create
+        (ZS,
+         Mode             => ZLib.Streams.In_Stream,
+         Back             => ZLib.Streams.Stream_Access (SA),
+         Back_Compressed  => True,
+         Header           => GZip,
+         Read_Buffer_Size => Buffer_Size);
+
+      if Plain = null then
+         while not ZS.End_Of_Stream loop
+            declare
+               Buffer : Stream_Element_Array (1 .. 1024);
+            begin
+               ZS.Read (Buffer, Last);
+               MS.Append (Collector, Buffer (1 .. Last));
+
+               if Last < Buffer'Last and then not ZS.End_Of_Stream then
+                  Text_IO.Put_Line
+                    ("EOF not detected" & Last'Img & Buffer'Length'Img);
+               end if;
+            end;
+         end loop;
+
+         Plain := new Stream_Element_Array (1 .. MS.Size (Collector));
+         MS.Read (Collector, Plain.all, Last);
+
+         if Last /= Plain'Last then
+            Text_IO.Put_Line ("Wrong Last" & Last'Img);
+         end if;
+
+         if MS.Pending (Collector) > 0 then
+            Text_IO.Put_Line ("Wrong pending" & MS.Pending (Collector)'Img);
+         end if;
+
+         MS.Close (Collector);
+
+      else
+         Stream_IO.Set_Index (F, 1);
+
+         declare
+            Buffer : Stream_Element_Array (Plain.all'Range);
+         begin
+            ZS.Read (Buffer, Last);
+            if Last /= Buffer'Last then
+               Text_IO.Put_Line
+                 ("Wrong Last" & Last'Img & " on buffer" & Buffer_Size'Img);
+            end if;
+
+            if Buffer /= Plain.all then
+               Text_IO.Put_Line
+                 ("Wrong inflate on buffer" & Buffer_Size'Img);
+            end if;
+
+            if not ZS.End_Of_Stream then
+               Text_IO.Put_Line
+                 ("End of stream is not detected on buffer" & Buffer_Size'Img);
+
+               ZS.Read (Buffer, Last);
+
+               if Last >= Buffer'First then
+                  Text_IO.Put_Line
+                    ("Inflate longer than expected on " & Buffer_Size'Img);
+               end if;
+
+               if not ZS.End_Of_Stream then
+                  Text_IO.Put_Line
+                    ("End of stream is not detected at all on buffer"
+                     & Buffer_Size'Img);
+               end if;
+            end if;
+         end;
+      end if;
+
+      ZS.Close;
+   end loop;
+
+   Stream_IO.Close (F);
+end Zeof;

--- a/regtests/0343_zsome/memory_some.adb
+++ b/regtests/0343_zsome/memory_some.adb
@@ -1,0 +1,32 @@
+with AWS.Utils;
+with Ada.Text_IO;
+
+package body Memory_Some is
+
+   ----------
+   -- Read --
+   ----------
+
+   overriding procedure Read
+     (Stream : in out Stream_Type;
+      Buffer :    out Stream_Element_Array;
+      Last   :    out Stream_Element_Offset)
+   is
+      use type AWS.Utils.Random_Integer;
+   begin
+      Last := Buffer'First +
+        Stream_Element_Offset (AWS.Utils.Random rem Buffer'Length);
+      MS.Read (Stream.Internal, Buffer (Buffer'First .. Last), Last);
+   end Read;
+
+   -----------
+   -- Write --
+   -----------
+
+   overriding procedure Write
+     (Stream : in out Stream_Type; Item : Stream_Element_Array) is
+   begin
+      MS.Append (Stream.Internal, Item);
+   end Write;
+
+end Memory_Some;

--- a/regtests/0343_zsome/memory_some.ads
+++ b/regtests/0343_zsome/memory_some.ads
@@ -1,0 +1,40 @@
+with Ada.Streams;
+private with AWS.Containers.Memory_Streams;
+
+package Memory_Some is
+
+   use Ada.Streams;
+
+   type Stream_Type is new Ada.Streams.Root_Stream_Type with private;
+
+   overriding procedure Read
+     (Stream : in out Stream_Type;
+      Buffer : out Stream_Element_Array;
+      Last   : out Stream_Element_Offset);
+   --  Returns a chunck of data in Buffer, Last point to the last element
+   --  returned in Buffer.
+   --  Last will be less then Buffer'Last in most cases, even if not at the end
+   --  of stream.
+
+   overriding procedure Write
+     (Stream : in out Stream_Type; Item : Stream_Element_Array);
+
+   function End_Of_Stream (Stream : Stream_Type) return Boolean;
+
+   function Size (Stream : Stream_Type) return Stream_Element_Offset;
+
+private
+
+   package MS renames AWS.Containers.Memory_Streams;
+
+   type Stream_Type is new Ada.Streams.Root_Stream_Type with record
+      Internal : MS.Stream_Type;
+   end record;
+
+   function End_Of_Stream (Stream : Stream_Type) return Boolean is
+     (MS.End_Of_File (Stream.Internal));
+
+   function Size (Stream : Stream_Type) return Stream_Element_Offset is
+     (MS.Size (Stream.Internal));
+
+end Memory_Some;

--- a/regtests/0343_zsome/test.opt
+++ b/regtests/0343_zsome/test.opt
@@ -1,0 +1,1 @@
+vxworks DEAD "block too big rasie STORAGE_ERROR"

--- a/regtests/0343_zsome/test.py
+++ b/regtests/0343_zsome/test.py
@@ -1,0 +1,4 @@
+from test_support import build_and_run
+
+
+build_and_run('zsome');

--- a/regtests/0343_zsome/zsome.adb
+++ b/regtests/0343_zsome/zsome.adb
@@ -1,0 +1,84 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                       Copyright (C) 2021, AdaCore                        --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with Ada.Streams;
+with Ada.Text_IO;
+
+with AWS.Resources.Streams.Memory.ZLib;
+with AWS.Utils;
+with Memory_Some;
+with ZLib.Streams;
+
+procedure ZSome is
+
+   use Ada.Streams;
+
+   Back   : aliased Memory_Some.Stream_Type;
+   Stream : ZLib.Streams.Stream_Type;
+   Sample : Stream_Element_Array (0 .. 255);
+   Buffer : Stream_Element_Array (Sample'Range);
+   Last   : Stream_Element_Offset;
+   Count  : constant := 50000;
+
+   procedure Print (Message : String) renames Ada.Text_IO.Put_Line;
+
+begin
+   for J in Sample'Range loop
+      Sample (J) := Stream_Element (J);
+   end loop;
+
+   Stream.Create
+     (Mode            => ZLib.Streams.Duplex,
+      Back            => Back'Unchecked_Access,
+      Back_Compressed => True);
+
+   for J in 1 .. Count loop
+      for K in Sample'Range loop
+         Buffer (K) := Sample (K) xor Stream_Element'Mod (J);
+      end loop;
+
+      Stream.Write (Buffer);
+   end loop;
+
+   Stream.Flush (ZLib.Finish);
+
+   for J in 1 .. Count loop
+      Stream.Read (Buffer, Last);
+
+      if Last < Buffer'Last then
+         Print ("Wrong Last" & Last'Img);
+      end if;
+
+      for K in Sample'Range loop
+         if Buffer (K) /= (Sample (K) xor Stream_Element'Mod (J)) then
+            Print ("Wrong buffer");
+         end if;
+      end loop;
+   end loop;
+
+   if not Stream.End_Of_Stream then
+      Print ("End of stream is not detected " & Back.End_Of_Stream'Img);
+
+      Stream.Read (Buffer, Last);
+
+      if Last >= Buffer'First then
+         Print ("Wrong data at tail");
+      end if;
+   end if;
+
+end ZSome;

--- a/regtests/0343_zsome/zsome.gpr
+++ b/regtests/0343_zsome/zsome.gpr
@@ -1,0 +1,24 @@
+------------------------------------------------------------------------------
+--                              Ada Web Server                              --
+--                                                                          --
+--                     Copyright (C) 2008-2021, AdaCore                     --
+--                                                                          --
+--  This is free software;  you can redistribute it  and/or modify it       --
+--  under terms of the  GNU General Public License as published  by the     --
+--  Free Software  Foundation;  either version 3,  or (at your option) any  --
+--  later version.  This software is distributed in the hope  that it will  --
+--  be useful, but WITHOUT ANY WARRANTY;  without even the implied warranty --
+--  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU     --
+--  General Public License for  more details.                               --
+--                                                                          --
+--  You should have  received  a copy of the GNU General  Public  License   --
+--  distributed  with  this  software;   see  file COPYING3.  If not, go    --
+--  to http://www.gnu.org/licenses for a complete copy of the license.      --
+------------------------------------------------------------------------------
+
+with "aws";
+
+project ZSome is
+   for Source_Dirs use (".");
+   for Main use ("zsome.adb");
+end ZSome;


### PR DESCRIPTION
When size of gzipped stream is few bytes more than multiple of
Read_Buffer_Size stream creation parameter, the end of stream can be
detected only after last empty read. To fix that we should try to read
and inflate ahead.

TN: U727-039