### PR TITLE
Fix context of request and responce

### DIFF
--- a/src/core/aws-server-context.ads
+++ b/src/core/aws-server-context.ads
@@ -40,9 +40,6 @@ package AWS.Server.Context is
       Tab_Enc  : not null access HTTP2.HPACK.Table.Object;
       Tab_Dec  : not null access HTTP2.HPACK.Table.Object;
       Settings : not null access HTTP2.Connection.Object)
-   is record
-      Status   : AWS.Status.Data;
-      Response : AWS.Response.Data;
-   end record;
+   is null record;
 
 end AWS.Server.Context;

--- a/src/core/aws-server.ads
+++ b/src/core/aws-server.ads
@@ -529,7 +529,7 @@ private
    type Line_Attribute_Record is record
       Server     : access HTTP;
       Line       : Positive;
-      Stat       : Status.Data;
+      Stat       : aliased Status.Data;
       Expect_100 : Boolean := False;
       Skip_Log   : Boolean := False;
       Log_Data   : Log.Fields_Table;

--- a/src/http2/aws-http2-stream.adb
+++ b/src/http2/aws-http2-stream.adb
@@ -77,6 +77,8 @@ package body AWS.HTTP2.Stream is
          H_Frames            => Frame.List.Empty_List,
          D_Frames            => Frame.List.Empty_List,
          Headers             => AWS.Headers.Empty_List,
+         Status              => <>,
+         Response            => <>,
          Is_Ready            => False,
          Header_Found        => False,
          Flow_Send_Window    => Window_Size,

--- a/src/http2/aws-http2-stream.ads
+++ b/src/http2/aws-http2-stream.ads
@@ -36,6 +36,7 @@ with AWS.Headers;
 with AWS.HTTP2.Frame;
 with AWS.HTTP2.Frame.List;
 with AWS.HTTP2.Frame.Priority;
+with AWS.Response;
 with AWS.Status;
 
 package AWS.HTTP2.Stream is
@@ -118,6 +119,10 @@ package AWS.HTTP2.Stream is
    function Bytes_Sent (Self : Object) return Stream_Element_Count;
    --  Number of payload bytes send over this stream
 
+   function Status (Self : Object) return not null access AWS.Status.Data;
+
+   function Response (Self : Object) return not null access AWS.Response.Data;
+
 private
 
    subtype Content_Length_Type is
@@ -132,6 +137,8 @@ private
       H_Frames            : Frame.List.Object; -- Header frames
       D_Frames            : Frame.List.Object; -- Data frames
       Headers             : AWS.Headers.List;
+      Status              : aliased AWS.Status.Data;
+      Response            : aliased AWS.Response.Data;
       Is_Ready            : Boolean              := False;
       Header_Found        : Boolean              := False;
       Flow_Send_Window    : Integer;
@@ -148,8 +155,14 @@ private
 
    Undefined : constant Object :=
                  (null, 0, Idle, Frame.List.Empty_List, Frame.List.Empty_List,
-                  AWS.Headers.Empty_List, False, False, 0, 0, 0, 0, 0, False,
-                  Undefined_Length, 0);
+                  Headers             => AWS.Headers.Empty_List,
+                  Status              => <>,
+                  Response            => <>,
+                  Flow_Send_Window    => 0,
+                  Flow_Receive_Window => 0,
+                  Weight              => 0,
+                  Stream_Dependency   => 0,
+                  others              => <>);
 
    function State (Self : Object) return State_Kind is (Self.State);
 
@@ -166,6 +179,12 @@ private
 
    function Headers (Self : Object) return AWS.Headers.List is
      (Self.Headers);
+
+   function Status (Self : Object) return not null access AWS.Status.Data is
+     (Self.Status'Unrestricted_Access);
+
+   function Response (Self : Object) return not null access AWS.Response.Data
+   is (Self.Response'Unrestricted_Access);
 
    function Is_Defined (Self : Object) return Boolean is (Self /= Undefined);
 


### PR DESCRIPTION
The right context of the HTTP/2 request and responce is not in the TCP
connection but in the HTTP/2 stream.
To check this put 2 few megabites length files into web_elements directory,
run demos/wps executable, and then call

h2load https://127.0.0.1:4433/{big-file-1,big-file-2} -v -w 14 -m 2 -n 8

TN: S507-051