### PR TITLE
Remove gzip -k option as not available on old versions.

### DIFF
--- a/regtests/0342_zlib_eof/test.py
+++ b/regtests/0342_zlib_eof/test.py
@@ -2,7 +2,7 @@ from test_support import build, exec_cmd, run
 
 
 build('default');
-exec_cmd("gzip", ["-k", "zeof.adb"])
-exec_cmd("gzip", ["-k", "zeof.ali"])
+exec_cmd("gzip", ["zeof.adb"])
+exec_cmd("gzip", ["zeof.ali"])
 run("zeof", ["zeof.adb.gz"])
 run("zeof", ["zeof.ali.gz"])


### PR DESCRIPTION
And this option is not needed for passing the test.

Continued work for U727-039.