### PR TITLE
Specialized the output for rhES8 on x86-linux.

### DIFF
--- a/regtests/0245_errcon/test-rhES8-x86.out
+++ b/regtests/0245_errcon/test-rhES8-x86.out
@@ -1,0 +1,4 @@
+[REFUSED] Connection refused to localhost 127.0.0.1:10123
+[REFUSED] Connection refused to 127.0.0.1:10123
+[UNREACH] Network is unreachable on connect to 255.255.255.255:10123
+[NO_NAME] Name or service not known: no-way.to-have.such-address

--- a/regtests/0245_errcon/test.opt
+++ b/regtests/0245_errcon/test.opt
@@ -15,7 +15,8 @@ darwin,gnat OUT test-darwin.out
 freebsd,!ipv4 OUT test-freebsd-ipv6.out
 freebsd,ipv4 OUT test-freebsd-ipv4.out
 vxworks6,!vxworks6-6.6 OUT test-vxworks.out
-linux-rhES8,x86 OUT test-rhES7-x86.out
+linux-rhES8,x86_64 OUT test-rhES7-x86.out
+linux-rhES8,x86 OUT test-rhES8-x86.out
 gnat OUT test.out
 ipv6 OUT test-ipv6.out
 ipv4,!vxworks6-6.6 OUT test-ipv4.out


### PR DESCRIPTION
For U906-032.