### PR TITLE
removed GNATcheck warnings

### DIFF
--- a/config/src/aws-net-std__gnat.adb
+++ b/config/src/aws-net-std__gnat.adb
@@ -258,13 +258,12 @@ package body AWS.Net.Std is
                      --  ??? Note, we should change this when GNAT will support
                      --  Non-blocking connect.
 
-                     case Resolve_Exception (E) is
-                        when Operation_Now_In_Progress
-                           | Resource_Temporarily_Unavailable =>
-                           null;
-                        when others =>
-                           raise;
-                     end case;
+                     if Resolve_Exception (E) not in
+                         Operation_Now_In_Progress |
+                           Resource_Temporarily_Unavailable
+                     then
+                        raise;
+                     end if;
                end;
 
                if Wait then

--- a/config/src/aws-net-std__ipv4.adb
+++ b/config/src/aws-net-std__ipv4.adb
@@ -230,12 +230,12 @@ package body AWS.Net.Std is
             --  ??? Note, we should change this when GNAT will support
             --  Non-blocking connect.
 
-            case Resolve_Exception (E) is
-               when Operation_Now_In_Progress
-                    | Resource_Temporarily_Unavailable => null;
-               when others =>
-                  Raise_Error (Exception_Message (E));
-            end case;
+            if Resolve_Exception (E) not in
+                Operation_Now_In_Progress |
+                  Resource_Temporarily_Unavailable
+            then
+               Raise_Error (Exception_Message (E));
+            end if;
       end;
 
       if Wait then

--- a/config/ssl/aws-net-ssl__gnutls.adb
+++ b/config/ssl/aws-net-ssl__gnutls.adb
@@ -630,19 +630,19 @@ package body AWS.Net.SSL is
    procedure Code_Processing
      (Code : C.int; Socket : Socket_Type'Class; Timeout : Duration) is
    begin
-      case Code is
-         when TSSL.GNUTLS_E_INTERRUPTED | TSSL.GNUTLS_E_AGAIN =>
-            case TSSL.gnutls_record_get_direction (Socket.SSL) is
-               when 0      => Wait_For (Input, Socket, Timeout);
-               when 1      => Wait_For (Output, Socket, Timeout);
-               when others =>
-                  Log_Error ("Unexpected gnutls_record_get_direction result");
-                  raise Program_Error;
-            end case;
-
-         when others =>
-            Check_Error_Code (Code, Socket);
-      end case;
+      if Code in TSSL.GNUTLS_E_INTERRUPTED | TSSL.GNUTLS_E_AGAIN then
+         case TSSL.gnutls_record_get_direction (Socket.SSL) is
+            when 0 =>
+               Wait_For (Input, Socket, Timeout);
+            when 1 =>
+               Wait_For (Output, Socket, Timeout);
+            when others =>
+               Log_Error ("Unexpected gnutls_record_get_direction result");
+               raise Program_Error;
+         end case;
+      else
+         Check_Error_Code (Code, Socket);
+      end if;
    end Code_Processing;
 
    procedure Code_Processing (Code : C.int; Socket : Socket_Type'Class) is

--- a/config/ssl/aws-net-ssl__openssl.adb
+++ b/config/ssl/aws-net-ssl__openssl.adb
@@ -1361,15 +1361,15 @@ package body AWS.Net.SSL is
    procedure Set_Session_Cache_Size
      (Context : TSSL.SSL_CTX; Size : Integer) is
    begin
-      case TSSL.SSL_CTX_set_session_cache_mode
-        (Ctx  => Context,
-         Mode => (if Size = 0 then TSSL.SSL_SESS_CACHE_OFF
-                  else TSSL.SSL_SESS_CACHE_SERVER))
-      is
-         when TSSL.SSL_SESS_CACHE_OFF | TSSL.SSL_SESS_CACHE_SERVER => null;
-         when others =>
-            raise Socket_Error with "Unexpected session cache mode";
-      end case;
+      if TSSL.SSL_CTX_set_session_cache_mode
+          (Ctx  => Context,
+           Mode =>
+             (if Size = 0 then TSSL.SSL_SESS_CACHE_OFF else TSSL.SSL_SESS_CACHE_SERVER)) not in
+          TSSL.SSL_SESS_CACHE_OFF |
+            TSSL.SSL_SESS_CACHE_SERVER
+      then
+         raise Socket_Error with "Unexpected session cache mode";
+      end if;
 
       Error_If
         (TSSL.SSL_CTX_ctrl

--- a/regtests/0118_test_net_log/test_net_log.adb
+++ b/regtests/0118_test_net_log/test_net_log.adb
@@ -16,6 +16,7 @@
 --  to http://www.gnu.org/licenses for a complete copy of the license.      --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 with Ada.Streams;
 with Ada.Text_IO; use Ada.Text_IO;
 
@@ -74,13 +75,15 @@ procedure Test_Net_Log is
          S1 := Last;
          S2 := Data'Last;
 
-         case Direction is
-            when Net.Log.Sent    =>
-               S1 := S1 - Adjust;
-               S2 := S2 - Adjust;
-            when Net.Log.Received =>
-               S1 := S1 - Adjust;
-         end case;
+         Ada.Assertions.Assert
+           (Check   => Direction in Net.Log.Sent | Net.Log.Received,
+            Message => "Value outside expected value set");
+         if Direction in Net.Log.Sent then
+            S1 := S1 - Adjust;
+            S2 := S2 - Adjust;
+         else
+            S1 := S1 - Adjust;
+         end if;
 
          Put_Line (F, "@@@ " & Net.Log.Data_Direction'Image (Direction)
                    & " (" &
@@ -117,10 +120,14 @@ procedure Test_Net_Log is
       end Write;
 
    begin
-      case Direction is
-         when Net.Log.Sent     => Write (DS);
-         when Net.Log.Received => Write (DR);
-      end case;
+      Ada.Assertions.Assert
+        (Check   => Direction in Net.Log.Sent | Net.Log.Received,
+         Message => "Value outside expected value set");
+      if Direction in Net.Log.Sent then
+         Write (DS);
+      else
+         Write (DR);
+      end if;
    end HTTP_Log;
 
    -----------

--- a/regtests/0317_hide_id/hide_id.adb
+++ b/regtests/0317_hide_id/hide_id.adb
@@ -16,6 +16,7 @@
 --  to http://www.gnu.org/licenses for a complete copy of the license.      --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 with Ada.Streams;
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Ada.Text_IO;           use Ada.Text_IO;
@@ -94,13 +95,15 @@ procedure Hide_Id is
                if Buffer (1 .. K - 1) = Default_User_Agent then
                   --  Adjust size depending on the AWS version length
 
-                  case Direction is
-                     when Net.Log.Sent    =>
-                        S1 := S1 - Adjust;
-                        S2 := S2 - Adjust;
-                     when Net.Log.Received =>
-                        S1 := S1 - Adjust;
-                  end case;
+                  Ada.Assertions.Assert
+                    (Check   => Direction in Net.Log.Sent | Net.Log.Received,
+                     Message => "Value outside expected value set");
+                  if Direction in Net.Log.Sent then
+                     S1 := S1 - Adjust;
+                     S2 := S2 - Adjust;
+                  else
+                     S1 := S1 - Adjust;
+                  end if;
                end if;
 
                Output := True;
@@ -133,17 +136,18 @@ procedure Hide_Id is
       end Write;
 
    begin
-      case Direction is
-         when Net.Log.Sent     =>
-            Write;
+      Ada.Assertions.Assert
+        (Check   => Direction in Net.Log.Sent | Net.Log.Received,
+         Message => "Value outside expected value set");
+      if Direction in Net.Log.Sent then
+         Write;
 
-            if R then
-               Put_Line (DS, To_String (F));
-            else
-               Answer_Data := F;
-            end if;
-         when Net.Log.Received => null;
-      end case;
+         if R then
+            Put_Line (DS, To_String (F));
+         else
+            Answer_Data := F;
+         end if;
+      end if;
 
    end HTTP_Log;
 

--- a/src/core/aws-hotplug.adb
+++ b/src/core/aws-hotplug.adb
@@ -27,6 +27,7 @@
 --  covered by the  GNU Public License.                                     --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 with AWS.Client;
 with AWS.Parameters;
 
@@ -177,21 +178,21 @@ package body AWS.Hotplug is
       Item := (To_Unbounded_String (Regexp), GNAT.Regexp.Compile (Regexp), U);
       Cursor := Filter_Table.Find (Filters.Set, Item);
 
-      case Filters.Mode is
-         when Add =>
-            if Filter_Table.Has_Element (Cursor) then
-               raise Register_Error;
-            else
-               Filter_Table.Append (Filters.Set, Item);
-            end if;
-
-         when Replace =>
-            if Filter_Table.Has_Element (Cursor) then
-               Filter_Table.Replace_Element (Filters.Set, Cursor, Item);
-            else
-               Filter_Table.Append (Filters.Set, Item);
-            end if;
-      end case;
+      Ada.Assertions.Assert
+        (Check => Filters.Mode in Add | Replace, Message => "Value outside expected value set");
+      if Filters.Mode in Add then
+         if Filter_Table.Has_Element (Cursor) then
+            raise Register_Error;
+         else
+            Filter_Table.Append (Filters.Set, Item);
+         end if;
+      else
+         if Filter_Table.Has_Element (Cursor) then
+            Filter_Table.Replace_Element (Filters.Set, Cursor, Item);
+         else
+            Filter_Table.Append (Filters.Set, Item);
+         end if;
+      end if;
    end Register;
 
    --------------

--- a/src/core/aws-messages.adb
+++ b/src/core/aws-messages.adb
@@ -27,6 +27,7 @@
 --  covered by the  GNU Public License.                                     --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 with Ada.Directories;
 
 with AWS.Headers.Values;
@@ -557,56 +558,50 @@ package body AWS.Messages is
            (Result, "max-age=" & Utils.Image (Integer (Data.Max_Age)));
       end if;
 
-      case Data.CKind is
-         when Request =>
-            if Data.Max_Stale /= Unset then
-               if Data.Max_Stale = Any_Max_Stale then
-                  Utils.Append_With_Sep (Result, "max-stale");
-               else
-                  Utils.Append_With_Sep
-                    (Result, "max-stale="
-                     & Utils.Image (Integer (Data.Max_Stale)));
-               end if;
-            end if;
-
-            if Data.Min_Fresh /= Unset then
+      Ada.Assertions.Assert
+        (Check => Data.CKind in Request | Response, Message => "Value outside expected value set");
+      if Data.CKind in Request then
+         if Data.Max_Stale /= Unset then
+            if Data.Max_Stale = Any_Max_Stale then
+               Utils.Append_With_Sep (Result, "max-stale");
+            else
                Utils.Append_With_Sep
-                 (Result, "min-fresh="
-                  & Utils.Image (Integer (Data.Min_Fresh)));
+                 (Result, "max-stale=" & Utils.Image (Integer (Data.Max_Stale)));
             end if;
+         end if;
 
-            if Data.Only_If_Cached then
-               Utils.Append_With_Sep (Result, "only-if-cached");
-            end if;
+         if Data.Min_Fresh /= Unset then
+            Utils.Append_With_Sep (Result, "min-fresh=" & Utils.Image (Integer (Data.Min_Fresh)));
+         end if;
 
-         when Response =>
-            if Data.S_Max_Age /= Unset then
-               Utils.Append_With_Sep
-                 (Result, "s-maxage="
-                  & Utils.Image (Integer (Data.S_Max_Age)));
-            end if;
+         if Data.Only_If_Cached then
+            Utils.Append_With_Sep (Result, "only-if-cached");
+         end if;
+      else
+         if Data.S_Max_Age /= Unset then
+            Utils.Append_With_Sep (Result, "s-maxage=" & Utils.Image (Integer (Data.S_Max_Age)));
+         end if;
 
-            if Data.Public then
-               Utils.Append_With_Sep (Result, "public");
-            end if;
+         if Data.Public then
+            Utils.Append_With_Sep (Result, "public");
+         end if;
 
-            if Data.Private_Field /= Private_Unset then
-               if Data.Private_Field = All_Private then
-                  Utils.Append_With_Sep (Result, "private");
-               else
-                  Utils.Append_With_Sep
-                    (Result, "private=" & To_String (Data.Private_Field));
-               end if;
+         if Data.Private_Field /= Private_Unset then
+            if Data.Private_Field = All_Private then
+               Utils.Append_With_Sep (Result, "private");
+            else
+               Utils.Append_With_Sep (Result, "private=" & To_String (Data.Private_Field));
             end if;
+         end if;
 
-            if Data.Must_Revalidate then
-               Utils.Append_With_Sep (Result, "must-revalidate");
-            end if;
+         if Data.Must_Revalidate then
+            Utils.Append_With_Sep (Result, "must-revalidate");
+         end if;
 
-            if Data.Proxy_Revalidate then
-               Utils.Append_With_Sep (Result, "proxy-revalidate");
-            end if;
-      end case;
+         if Data.Proxy_Revalidate then
+            Utils.Append_With_Sep (Result, "proxy-revalidate");
+         end if;
+      end if;
 
       return Cache_Option (To_String (Result));
    end To_Cache_Option;

--- a/src/core/aws-net-websocket-protocol-rfc6455.adb
+++ b/src/core/aws-net-websocket-protocol-rfc6455.adb
@@ -239,15 +239,17 @@ package body AWS.Net.WebSocket.Protocol.RFC6455 is
 
    function Is_Valid_Close_Code (Error : Error_Type) return Boolean is
    begin
-      case Error is
-         when Normal_Closure | Going_Away | Protocol_Error | Unsupported_Data
-           | Invalid_Frame_Payload_Data .. Internal_Server_Error
-           =>
-            return True;
-
-         when others =>
-            return False;
-      end case;
+      if Error in
+          Normal_Closure     |
+            Going_Away       |
+            Protocol_Error   |
+            Unsupported_Data |
+            Invalid_Frame_Payload_Data .. Internal_Server_Error
+      then
+         return True;
+      else
+         return False;
+      end if;
    end Is_Valid_Close_Code;
 
    -------------
@@ -464,16 +466,13 @@ package body AWS.Net.WebSocket.Protocol.RFC6455 is
 
                      --  If we have a wrong code this is a Protocol_Error
 
-                     if (Is_Library_Error (E)
-                         or else Is_Valid_Close_Code (Error (Socket)))
-                       and then
-                         --  A close message must be a valid UTF-8 string
-                         Utils.Is_Valid_UTF8
-                           (Translator.To_String
-                             (Data (Data'First + 2 .. Last)))
+                     if not
+                       ((Is_Library_Error (E) or else Is_Valid_Close_Code (Error (Socket)))
+                        and then
+                        --  A close message must be a valid UTF-8 string
+                        Utils.Is_Valid_UTF8
+                          (Translator.To_String (Data (Data'First + 2 .. Last))))
                      then
-                        null;
-                     else
                         E := Error_Code (Protocol_Error);
                      end if;
 

--- a/src/core/aws-net-websocket-registry.adb
+++ b/src/core/aws-net-websocket-registry.adb
@@ -29,6 +29,7 @@
 
 pragma Ada_2012;
 
+with Ada.Assertions;
 with Ada.Containers.Indefinite_Ordered_Maps;
 with Ada.Containers.Indefinite_Vectors;
 with Ada.Containers.Ordered_Maps;
@@ -432,9 +433,9 @@ package body AWS.Net.WebSocket.Registry is
          Registered_Before : constant WebSocket_Map.Map := Registered;
 
       begin
-         case To.Kind is
-            when K_UID =>
-               if Registered.Contains (To.WS_Id) then
+Ada.Assertions.Assert (Check => To.Kind in K_UID | K_URI,                       Message => "Value outside expected value set");
+if To.Kind in K_UID then
+   if Registered.Contains (To.WS_Id) then
                   declare
                      WebSocket : constant not null access Object'Class :=
                                    Registered (To.WS_Id);
@@ -454,10 +455,9 @@ package body AWS.Net.WebSocket.Registry is
                     with "WebSocket " & Utils.Image (Natural (To.WS_Id))
                          & " is not registered";
                end if;
-
-            when K_URI =>
-               Registered_Before.Iterate (Close_To'Access);
-         end case;
+else
+   Registered_Before.Iterate (Close_To'Access);
+end if;
       end Close;
 
       procedure Close
@@ -857,13 +857,10 @@ package body AWS.Net.WebSocket.Registry is
                         else
                            Error (W.all, A);
 
-                           case A is
-                              when Close =>
-                                 DB.Unregister (W);
-                                 Unchecked_Free (W);
-                              when None =>
-                                 null;
-                           end case;
+Ada.Assertions.Assert (Check => A in Close | None,                       Message => "Value outside expected value set");
+if A in Close then
+ DB.Unregister (W);
+                                 Unchecked_Free (W);end if;
                         end if;
                      end;
                   end loop;
@@ -962,9 +959,9 @@ package body AWS.Net.WebSocket.Registry is
          end Send_To_Recipients;
 
       begin
-         case To.Kind is
-            when K_UID =>
-               if Registered.Contains (To.WS_Id) then
+Ada.Assertions.Assert (Check => To.Kind in K_UID | K_URI,                       Message => "Value outside expected value set");
+if To.Kind in K_UID then
+   if Registered.Contains (To.WS_Id) then
                   declare
                      WebSocket : Object_Class := Registered (To.WS_Id);
                   begin
@@ -990,14 +987,13 @@ package body AWS.Net.WebSocket.Registry is
                     with "WebSocket " & Utils.Image (Natural (To.WS_Id))
                          & " is not registered";
                end if;
-
-            when K_URI =>
-               Registered.Iterate (Initialize_Recipients'Access);
+else
+   Registered.Iterate (Initialize_Recipients'Access);
 
                if Last > 0 then
                   Send_To_Recipients (Recipients (1 .. Last));
                end if;
-         end case;
+end if;
       end Send;
 
       procedure Send

--- a/src/core/aws-response-set.adb
+++ b/src/core/aws-response-set.adb
@@ -324,20 +324,18 @@ package body AWS.Response.Set is
    function Is_Valid (D : Data) return Boolean is
       Redirection_Code : Boolean;
    begin
-      case D.Status_Code is
-         when
-           Messages.S300 | -- Section 10.3.1: Multiple Choices
-           Messages.S301 | -- Section 10.3.2: Moved Permanently
-           Messages.S302 | -- Section 10.3.3: Found
-           Messages.S303 | -- Section 10.3.4: See Other
-           Messages.S305 | -- Section 10.3.6: Use Proxy
-           Messages.S307   -- Section 10.3.8: Temporary Redirect
-           =>
-            Redirection_Code := True;
-
-         when others =>
-            Redirection_Code := False;
-      end case;
+      if D.Status_Code in
+          Messages.S300   | -- Section 10.3.1: Multiple Choices
+            Messages.S301 | -- Section 10.3.2: Moved Permanently
+            Messages.S302 | -- Section 10.3.3: Found
+            Messages.S303 | -- Section 10.3.4: See Other
+            Messages.S305 | -- Section 10.3.6: Use Proxy
+            Messages.S307
+      then
+         Redirection_Code := True;
+      else
+         Redirection_Code := False;
+      end if;
 
       return (Redirection_Code
                 xor not Headers.Exist

--- a/src/core/aws-translator.adb
+++ b/src/core/aws-translator.adb
@@ -182,30 +182,22 @@ package body AWS.Translator is
       State : in out Decoding_State;
       Ch    : Character) is
    begin
-      if Ch /= '=' and then Base64_Values (Ch) = 16#ffffffff# then
-         null;
-
-      else
-         case Ch is
-            when '=' =>
-               State.Pad := State.Pad + 1;
-
-            when others =>
-               State.Group := State.Group
-                 or Shift_Left (Base64_Values (Ch), State.J);
-         end case;
-
+      if not (Ch /= '=' and then Base64_Values (Ch) = 16#ffff_ffff#) then
+         if Ch in '=' then
+            State.Pad := State.Pad + 1;
+         else
+            State.Group := State.Group or Shift_Left (Base64_Values (Ch), State.J);
+         end if;
          State.J := State.J - 6;
 
          if State.J < 0 then
-            Add (Character'Val (Shift_Right (State.Group and 16#FF0000#, 16)));
-            Add (Character'Val (Shift_Right (State.Group and 16#00FF00#, 8)));
-            Add (Character'Val (State.Group and 16#0000FF#));
+            Add (Character'Val (Shift_Right (State.Group and 16#FF_0000#, 16)));
+            Add (Character'Val (Shift_Right (State.Group and 16#00_FF00#, 8)));
+            Add (Character'Val (State.Group and 16#00_00FF#));
 
             State.Group := 0;
             State.J     := 18;
          end if;
-
       end if;
    end Add;
 

--- a/src/extended/aws-net-log-callbacks.adb
+++ b/src/extended/aws-net-log-callbacks.adb
@@ -29,6 +29,7 @@
 
 pragma Ada_2012;
 
+with Ada.Assertions;
 with Ada.Integer_Text_IO;
 with Ada.Strings.Fixed;
 with Ada.Strings.Maps.Constants;
@@ -210,10 +211,13 @@ package body AWS.Net.Log.Callbacks is
    begin
       Text_IO.Put (File, "Data ");
 
-      case Direction is
-         when Sent     => Text_IO.Put (File, "sent to ");
-         when Received => Text_IO.Put (File, "received from ");
-      end case;
+      Ada.Assertions.Assert
+        (Check => Direction in Sent | Received, Message => "Value outside expected value set");
+      if Direction in Sent then
+         Text_IO.Put (File, "sent to ");
+      else
+         Text_IO.Put (File, "received from ");
+      end if;
 
       Text_IO.Put (File, "socket " & Utils.Image (Get_FD (Socket)));
       Text_IO.Put_Line

--- a/src/http2/aws-http2-stream.adb
+++ b/src/http2/aws-http2-stream.adb
@@ -262,9 +262,9 @@ package body AWS.HTTP2.Stream is
       Has_Prev_Frame : constant Boolean := Self.H_Frames.Length > 0;
 
       End_Header     : constant Boolean :=
-                         (Frame.Has_Flag (HTTP2.Frame.End_Headers_Flag));
+                         Frame.Has_Flag (HTTP2.Frame.End_Headers_Flag);
       End_Stream     : constant Boolean :=
-                         (Frame.Has_Flag (HTTP2.Frame.End_Stream_Flag));
+                         Frame.Has_Flag (HTTP2.Frame.End_Stream_Flag);
 
    begin
       Error := C_No_Error;
@@ -310,16 +310,13 @@ package body AWS.HTTP2.Stream is
             end case;
 
          when Reserved_Local =>
-            case Frame.Kind is
-               when K_RST_Stream =>
-                  Self.State := Closed;
-               when others =>
-                  if End_Stream then
-                     Self.State := Half_Closed_Remote;
-                  else
-                     null;
-                  end if;
-            end case;
+            if Frame.Kind in K_RST_Stream then
+               Self.State := Closed;
+            else
+               if End_Stream then
+                  Self.State := Half_Closed_Remote;
+               end if;
+            end if;
 
          when Reserved_Remote =>
             case Frame.Kind is
@@ -333,17 +330,14 @@ package body AWS.HTTP2.Stream is
             end case;
 
          when Half_Closed_Local =>
-            case Frame.Kind is
-               when K_RST_Stream =>
-                  Self.State := Closed;
-               when others =>
-                  if End_Stream then
-                     Error := C_Protocol_Error;
-                     return;
-                  else
-                     null;
-                  end if;
-            end case;
+            if Frame.Kind in K_RST_Stream then
+               Self.State := Closed;
+            else
+               if End_Stream then
+                  Error := C_Protocol_Error;
+                  return;
+               end if;
+            end if;
 
          when Half_Closed_Remote =>
             case Frame.Kind is
@@ -527,7 +521,7 @@ package body AWS.HTTP2.Stream is
       Frame : HTTP2.Frame.Object'Class)
    is
       End_Header : constant Boolean :=
-                     (Frame.Has_Flag (HTTP2.Frame.End_Headers_Flag));
+                     Frame.Has_Flag (HTTP2.Frame.End_Headers_Flag);
       End_Stream : constant Boolean :=
                      Frame.Has_Flag (HTTP2.Frame.End_Stream_Flag);
    begin
@@ -589,32 +583,23 @@ package body AWS.HTTP2.Stream is
             end case;
 
          when Half_Closed_Local =>
-            case Frame.Kind is
-               when K_RST_Stream =>
-                  Self.State := Closed;
-               when others =>
-                  null;
-            end case;
+            if Frame.Kind in K_RST_Stream then
+               Self.State := Closed;
+            end if;
 
          when Half_Closed_Remote =>
-            case Frame.Kind is
-               when K_RST_Stream =>
+            if Frame.Kind in K_RST_Stream then
+               Self.State := Closed;
+            else
+               if End_Stream then
                   Self.State := Closed;
-               when others =>
-                  if End_Stream then
-                     Self.State := Closed;
-                  else
-                     null;
-                  end if;
-            end case;
+               end if;
+            end if;
 
          when Closed =>
-            case Frame.Kind is
-               when K_Priority =>
-                  null;
-               when others =>
-                  null;
-            end case;
+            if Frame.Kind in K_Priority then
+               null;
+            end if;
       end case;
 
       --  Update stream's Flow Control Window

--- a/tools/wsdl2aws-generator.adb
+++ b/tools/wsdl2aws-generator.adb
@@ -27,6 +27,7 @@
 --  covered by the  GNU Public License.                                     --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 with Ada.Calendar;
 with Ada.Characters.Handling;
 with Ada.Containers.Indefinite_Ordered_Sets;
@@ -1380,9 +1381,9 @@ package body WSDL2AWS.Generator is
                         then P.Typ
                         else Def.E_Type);
          Q_Name  : constant String :=
-                     (WSDL.Types.Name
+                     WSDL.Types.Name
                         (E_Type.Ref,
-                         NS => E_Type.Mode = WSDL.Types.K_Derived));
+                         NS => E_Type.Mode = WSDL.Types.K_Derived);
          T_Name  : constant String :=
                      (if WSDL.Types.Is_Character (E_Type)
                       then SOAP.Utils.No_NS (Q_Name)
@@ -4604,13 +4605,12 @@ package body WSDL2AWS.Generator is
             end;
          end if;
 
-         case Elab is
-            when Off =>
-               null;
-
-            when Single | Children =>
-               Text_IO.Put_Line (File, "pragma Elaborate_All (" & Name & ");");
-         end case;
+         Ada.Assertions.Assert
+           (Check   => Elab in Off | Single | Children,
+            Message => "Value outside expected value set");
+         if Elab in Single | Children then
+            Text_IO.Put_Line (File, "pragma Elaborate_All (" & Name & ");");
+         end if;
 
          if Use_Clause then
             Text_IO.Put_Line (File, "use " & Name & ';');

--- a/tools/wsdl2aws-wsdl-parser.adb
+++ b/tools/wsdl2aws-wsdl-parser.adb
@@ -29,6 +29,7 @@
 
 pragma Ada_2012;
 
+with Ada.Assertions;
 with Ada.Characters.Handling;
 with Ada.Containers.Indefinite_Vectors;
 with Ada.Directories;
@@ -304,13 +305,13 @@ package body WSDL2AWS.WSDL.Parser is
      (O    : Object'Class;
       Kind : Parameter_Mode) return SOAP.Types.Encoding_Style is
    begin
-      case Kind is
-         when Input =>
-            return O.I_Encoding;
-         when Output | Fault =>
-            --  ??? fault taken as output
-            return O.O_Encoding;
-      end case;
+      Ada.Assertions.Assert
+        (Check => Kind in Input | Output | Fault, Message => "Value outside expected value set");
+      if Kind in Input then
+         return O.I_Encoding;
+      else
+         return O.O_Encoding;
+      end if;
    end Encoding;
 
    ---------


### PR DESCRIPTION
removed GNATcheck warnings related to rule 11.1.5.6. Binary_Case_statements

Note 1. The changed statements have been pretty printed which might have caused a few more changes than strictly necessary.
Note 2. All subrules (like replace `not (x in y)` by `x not in y`) to get maximally readable code are applied on files with changed case statements. These subrules sometime also change other parts of the files not related to the original / changed case statements.

Note 3. I am curious what the build pipeline produces on other platforms than I have available.