### PR TITLE
Fix warning

### DIFF
--- a/src/core/aws-server.ads
+++ b/src/core/aws-server.ads
@@ -536,7 +536,7 @@ private
    end record;
 
    package Line_Attribute is new Ada.Task_Attributes
-     (Line_Attribute_Record, (Line => 1, others => <>));
+     (Line_Attribute_Record, Line_Attribute_Record'(Line => 1, others => <>));
    --  A line specific attribute
 
    procedure Null_Procedure is null;


### PR DESCRIPTION
no-tn-check

Use record name in constant to avoid
warning: component "SERVER" of type access to "HTTP" is uninitialized