### PR TITLE
Fix connection flow control

### DIFF
--- a/config/ssl/aws-net-ssl__gnutls.adb
+++ b/config/ssl/aws-net-ssl__gnutls.adb
@@ -469,10 +469,10 @@ package body AWS.Net.SSL is
                   (Socket.SSL, Datum'Access);
    begin
       if Code = TSSL.GNUTLS_E_REQUESTED_DATA_NOT_AVAILABLE then
-         Datum.data := System.Null_Address;
-      else
-         Check_Error_Code (Code);
+         return "";
       end if;
+
+      Check_Error_Code (Code);
 
       if Datum.data = System.Null_Address then
          return "";
@@ -480,6 +480,17 @@ package body AWS.Net.SSL is
 
       return To_String (Datum);
    end ALPN_Get;
+
+   ------------------
+   -- ALPN_Include --
+   ------------------
+
+   procedure ALPN_Include (Config : SSL.Config; Protocol : String) is
+   begin
+      if not Config.ALPN.Contains (Protocol) then
+         Config.ALPN.Append (Protocol);
+      end if;
+   end ALPN_Include;
 
    --------------
    -- ALPN_Set --

--- a/regtests/0334_alpn/test.out
+++ b/regtests/0334_alpn/test.out
@@ -4,5 +4,6 @@ Protocol: "ap2"
 Protocol: "ap2"
 Protocol: "ap3"
 Protocol: ""
+Protocol: "ap3"
 client task done.
 done.

--- a/src/core/aws-client-http_utils.adb
+++ b/src/core/aws-client-http_utils.adb
@@ -1927,6 +1927,10 @@ package body AWS.Client.HTTP_Utils is
                      (Connection.Socket.all, H_Connection);
       begin
          if Frame.Kind /= K_Settings then
+            if HTTP2.Debug then
+               Frame.Dump ("UNEXPECTED");
+            end if;
+
             raise Constraint_Error with
               "server should have answered with a setting frame";
 

--- a/src/core/aws-client.adb
+++ b/src/core/aws-client.adb
@@ -218,6 +218,12 @@ package body AWS.Client is
          else
             Connection.SSL_Config := SSL_Config;
          end if;
+
+         if HTTP_Version = HTTPv2 then
+            Net.SSL.ALPN_Set
+              (Connection.SSL_Config,
+               Net.SSL.SV.To_Vector (Messages.H2_Token, 1));
+         end if;
       end if;
 
       if Persistent and then Connection.Retry = 0 then

--- a/src/core/aws-client.adb
+++ b/src/core/aws-client.adb
@@ -220,9 +220,7 @@ package body AWS.Client is
          end if;
 
          if HTTP_Version = HTTPv2 then
-            Net.SSL.ALPN_Set
-              (Connection.SSL_Config,
-               Net.SSL.SV.To_Vector (Messages.H2_Token, 1));
+            Net.SSL.ALPN_Include (Connection.SSL_Config, Messages.H2_Token);
          end if;
       end if;
 

--- a/src/core/aws-net-ssl.ads
+++ b/src/core/aws-net-ssl.ads
@@ -189,6 +189,9 @@ package AWS.Net.SSL is
    --  supported ALPN protocols (Application Layer Protocol Negotiation), which
    --  are used during negotiation with peer.
 
+   procedure ALPN_Include (Config : SSL.Config; Protocol : String);
+   --  Append protocol into ALPN if it was not there
+
    procedure Release (Config : in out SSL.Config);
    --  Release memory associated with the Config object
 

--- a/src/core/aws-server-http_utils.adb
+++ b/src/core/aws-server-http_utils.adb
@@ -1945,28 +1945,30 @@ package body AWS.Server.HTTP_Utils is
       Line_Index  : Positive;
       File        : in out Resources.File_Type;
       Start       : Stream_Element_Offset;
+      Chunk_Size  : Stream_Element_Count;
       Length      : in out Resources.Content_Length_Type)
    is
-      --  Size of the buffer used to send the file
-      Buffer : Streams.Stream_Element_Array (1 .. Chunk_Size);
-      Last   : Streams.Stream_Element_Offset;
-      Stop   : Boolean := False;
+      Next_Size : Stream_Element_Count := Chunk_Size;
    begin
       Resources.Set_Index (File, Start);
 
-      begin
-         loop
+      loop
+         declare
+            --  Size of the buffer used to send the file
+            Last   : Streams.Stream_Element_Offset;
+            Buffer : Streams.Stream_Element_Array (1 .. Next_Size);
+         begin
             Resources.Read (File, Buffer, Last);
 
             if Resources.End_Of_File (File) then
-               Stop := True;
+               Next_Size := 0;
             end if;
 
-            Data (Buffer (1 .. Last), Stop);
+            Data (Buffer (1 .. Last), Next_Size);
 
             Length := Length + Last;
 
-            exit when Stop;
+            exit when Next_Size = 0;
 
             --  HTTP_Server is only set when used in server context. When used
             --  in client context it is not defined and we do not check for
@@ -1975,8 +1977,8 @@ package body AWS.Server.HTTP_Utils is
             if HTTP_Server /= null then
                HTTP_Server.Slots.Check_Data_Timeout (Line_Index);
             end if;
-         end loop;
-      end;
+         end;
+      end loop;
    end Send_File_G;
 
    -------------------
@@ -2029,8 +2031,8 @@ package body AWS.Server.HTTP_Utils is
 
       procedure Send_File is
          procedure Data_Received
-           (Content : Stream_Element_Array;
-            Stop    : in out Boolean);
+           (Content   : Stream_Element_Array;
+            Next_Size : in out Stream_Element_Count);
          --  New data received
 
          -------------------
@@ -2038,10 +2040,10 @@ package body AWS.Server.HTTP_Utils is
          -------------------
 
          procedure Data_Received
-           (Content : Stream_Element_Array;
-            Stop    : in out Boolean)
+           (Content   : Stream_Element_Array;
+            Next_Size : in out Stream_Element_Count)
          is
-            pragma Unreferenced (Stop);
+            pragma Unreferenced (Next_Size);
          begin
             Net.Buffered.Write (Sock, Content);
          end Data_Received;
@@ -2049,7 +2051,10 @@ package body AWS.Server.HTTP_Utils is
          procedure Send_File_Content is new Send_File_G (Data_Received);
 
       begin
-         Send_File_Content (HTTP_Server, Line_Index, File, 1, Length);
+         Send_File_Content
+           (HTTP_Server, Line_Index, File, 1,
+            Chunk_Size => 4 * 1024,
+            Length     => Length);
       end Send_File;
 
       ---------------------

--- a/src/core/aws-server-http_utils.adb
+++ b/src/core/aws-server-http_utils.adb
@@ -1279,6 +1279,10 @@ package body AWS.Server.HTTP_Utils is
       loop
          declare
             Data : constant String := Net.Buffered.Get_Line (Sock);
+
+            function Is_Next (Item : String) return Boolean is
+              (Net.Buffered.Get_Line (Sock) = Item);
+
          begin
             --  RFC 2616
             --  4.1 Message Types
@@ -1288,12 +1292,11 @@ package body AWS.Server.HTTP_Utils is
 
             if Data /= "" then
                if not Sock.Is_Secure
-                 and then Data = HTTP2.Client_Connection_Preface_1
-                 and then Net.Buffered.Get_Line (Sock) = ""
-                 and then Net.Buffered.Get_Line (Sock) =
-                            HTTP2.Client_Connection_Preface_2
-                 and then Net.Buffered.Get_Line (Sock) = ""
                  and then Status.Protocol (C_Stat) = Status.HTTP_1
+                 and then Data = HTTP2.Client_Connection_Preface_1
+                 and then Is_Next ("")
+                 and then Is_Next (HTTP2.Client_Connection_Preface_2)
+                 and then Is_Next ("")
                then
                   --  Plain socket client starts with HTTP/2 connection
                   --  preface, i.e. client assume that server has HTTP/2

--- a/src/core/aws-server-http_utils.ads
+++ b/src/core/aws-server-http_utils.ads
@@ -118,13 +118,14 @@ package AWS.Server.HTTP_Utils is
 
    generic
       with procedure Data
-        (Content : Stream_Element_Array; Stop : in out Boolean);
-      Chunk_Size : Stream_Element_Count := 4 * 1024;
+        (Content   : Stream_Element_Array;
+         Next_Size : in out Stream_Element_Count);
    procedure Send_File_G
      (HTTP_Server : access AWS.Server.HTTP;
       Line_Index  : Positive;
       File        : in out Resources.File_Type;
       Start       : Stream_Element_Offset;
+      Chunk_Size  : Stream_Element_Count;
       Length      : in out Resources.Content_Length_Type);
 
    procedure Send_Resource

--- a/src/core/aws-server-protocol_handler_v2.adb
+++ b/src/core/aws-server-protocol_handler_v2.adb
@@ -58,8 +58,6 @@ with AWS.HTTP2.Frame.List;
 with AWS.HTTP2.Frame.Ping;
 with AWS.HTTP2.Frame.RST_Stream;
 with AWS.HTTP2.Frame.Settings;
-with AWS.HTTP2.Frame.Settings;
-with AWS.HTTP2.Frame.Window_Update;
 with AWS.HTTP2.HPACK.Table;
 with AWS.HTTP2.Message.List;
 with AWS.HTTP2.Stream.Set;
@@ -177,91 +175,18 @@ is
       Streams : in out HTTP2.Stream.Set.Object;
       Error   : out HTTP2.Error_Codes)
    is
+      Add_FC : Integer;
+   begin
+      Ctx.Settings.Handle_Control_Frame (Frame, Answers, Add_FC, Error);
 
-      procedure Handle (Frame : HTTP2.Frame.Settings.Object);
-      --  Handle settings frame values
-
-      procedure Handle (Frame : HTTP2.Frame.Window_Update.Object);
-      --  Handle window update frame value
-
-      package S renames HTTP2.Frame.Settings;
-
-      ------------
-      -- Handle --
-      ------------
-
-      procedure Handle (Frame : HTTP2.Frame.Settings.Object) is
-         use type S.Settings_Kind;
-
-         Initial_Window_Size : constant Integer :=
-                                 Settings.Initial_Window_Size;
-      begin
-         Settings.Set (Frame.Values);
-
-         --  Update the control flow window size of all streams
-
-         for V of Frame.Values loop
-            if V.Id = S.INITIAL_WINDOW_SIZE then
-               declare
-                  Value : constant Natural := Integer (V.Value);
-                  Incr  : constant Integer := Value
-                                                - Initial_Window_Size;
-               begin
-                  for S of Streams loop
-                     if HTTP2.Connection.Flow_Control_Window_Valid
-                       (S.Flow_Control_Window, Value)
-                     then
-                        S.Update_Flow_Control_Window (Incr);
-                     end if;
-                  end loop;
-               end;
+      if Add_FC /= 0 then
+         for S of Streams loop
+            if HTTP2.Connection.Flow_Control_Window_Valid
+                 (S.Flow_Control_Window, Add_FC)
+            then
+               S.Update_Flow_Control_Window (Add_FC);
             end if;
          end loop;
-      end Handle;
-
-      procedure Handle (Frame : HTTP2.Frame.Window_Update.Object) is
-         Incr : constant Natural := Natural (Frame.Size_Increment);
-      begin
-         if HTTP2.Connection.Flow_Control_Window_Valid
-           (Settings.Flow_Control_Window, Incr)
-         then
-            Settings.Update_Flow_Control_Window
-              (Natural (Frame.Size_Increment));
-         else
-            Error := HTTP2.C_Flow_Control_Error;
-            return;
-         end if;
-      end Handle;
-
-   begin
-      Error := HTTP2.C_No_Error;
-
-      if Frame.Kind = K_Ping
-        and then not Frame.Has_Flag (HTTP2.Frame.Ack_Flag)
-      then
-         --  A probing ping frame, respond now with the same
-         --  payload (see RFC-7540 / 6.7).
-
-         declare
-            R_Ping : HTTP2.Frame.Object'Class := Frame;
-         begin
-            R_Ping.Set_Flags (HTTP2.Frame.Ack_Flag);
-            Answers.Prepend (R_Ping);
-         end;
-
-      elsif Frame.Kind = K_Settings
-        and then not Frame.Has_Flag (HTTP2.Frame.Ack_Flag)
-      then
-         Handle (HTTP2.Frame.Settings.Object (Frame));
-         Answers.Prepend (HTTP2.Frame.Settings.Ack);
-
-      elsif Frame.Kind = K_Settings
-        and then Frame.Has_Flag (HTTP2.Frame.Ack_Flag)
-      then
-         Answers.Prepend (HTTP2.Frame.Settings.Ack);
-
-      elsif Frame.Kind = K_Window_Update then
-         Handle (HTTP2.Frame.Window_Update.Object (Frame));
       end if;
    end Handle_Control_Frame;
 

--- a/src/core/aws-server.adb
+++ b/src/core/aws-server.adb
@@ -494,6 +494,10 @@ package body AWS.Server is
      (Web_Server : in out HTTP; SSL_Config : Net.SSL.Config) is
    begin
       Web_Server.SSL_Config := SSL_Config;
+
+      if CNF.HTTP2_Activated (Web_Server.Properties) then
+         Net.SSL.ALPN_Include (Web_Server.SSL_Config, Messages.H2_Token);
+      end if;
    end Set_SSL_Config;
 
    --------------------------------------
@@ -1089,34 +1093,32 @@ package body AWS.Server is
    begin
       --  If it is an SSL connection, initialize the SSL library
 
-      if CNF.Security (Web_Server.Properties)
-        and then Web_Server.SSL_Config = Net.SSL.Null_Config
-      then
-         Net.SSL.Initialize
-           (Web_Server.SSL_Config,
-            CNF.Certificate (Web_Server.Properties),
-            Security_Mode,
-            Priorities           =>
-              CNF.Cipher_Priorities (Web_Server.Properties),
-            Ticket_Support       =>
-              CNF.TLS_Ticket_Support (Web_Server.Properties),
-            Key_Filename         =>
-              CNF.Key (Web_Server.Properties),
-            Exchange_Certificate =>
-              CNF.Exchange_Certificate (Web_Server.Properties),
-            Certificate_Required =>
-              CNF.Certificate_Required (Web_Server.Properties),
-            Trusted_CA_Filename  =>
-              CNF.Trusted_CA (Web_Server.Properties),
-            CRL_Filename         =>
-              CNF.CRL_File (Web_Server.Properties),
-            Session_Cache_Size   =>
-              CNF.SSL_Session_Cache_Size (Web_Server.Properties));
+      if CNF.Security (Web_Server.Properties) then
+         if Web_Server.SSL_Config = Net.SSL.Null_Config then
+            Net.SSL.Initialize
+              (Web_Server.SSL_Config,
+               CNF.Certificate (Web_Server.Properties),
+               Security_Mode,
+               Priorities           =>
+                 CNF.Cipher_Priorities (Web_Server.Properties),
+               Ticket_Support       =>
+                 CNF.TLS_Ticket_Support (Web_Server.Properties),
+               Key_Filename         =>
+                 CNF.Key (Web_Server.Properties),
+               Exchange_Certificate =>
+                 CNF.Exchange_Certificate (Web_Server.Properties),
+               Certificate_Required =>
+                 CNF.Certificate_Required (Web_Server.Properties),
+               Trusted_CA_Filename  =>
+                 CNF.Trusted_CA (Web_Server.Properties),
+               CRL_Filename         =>
+                 CNF.CRL_File (Web_Server.Properties),
+               Session_Cache_Size   =>
+                 CNF.SSL_Session_Cache_Size (Web_Server.Properties));
+         end if;
 
          if CNF.HTTP2_Activated (Web_Server.Properties) then
-            Net.SSL.ALPN_Set
-              (Web_Server.SSL_Config,
-               Net.SSL.SV.To_Vector (Messages.H2_Token, 1));
+            Net.SSL.ALPN_Include (Web_Server.SSL_Config, Messages.H2_Token);
          end if;
       end if;
 

--- a/src/core/aws-utils.adb
+++ b/src/core/aws-utils.adb
@@ -352,6 +352,35 @@ package body AWS.Utils is
       end if;
    end Dequote;
 
+   -----------------
+   -- Dump_Binary --
+   -----------------
+
+   procedure Dump_Binary (Data : Stream_Element_Array) is
+      use Ada.Text_IO;
+
+      Printable : Boolean := True;
+   begin
+      for E of Data loop
+         Put (Hex (Natural (E), 2));
+         Put (" ");
+
+         if Character'Val (E) not in ASCII.CR | ASCII.LF | ' ' .. '~' then
+            Printable := False;
+         end if;
+      end loop;
+      New_Line;
+
+      if Printable then
+         Put ('"');
+         for E of Data loop
+            Put (Character'Val (E));
+         end loop;
+         Put ('"');
+         New_Line;
+      end if;
+   end Dump_Binary;
+
    ---------------
    -- File_Size --
    ---------------

--- a/src/core/aws-utils.ads
+++ b/src/core/aws-utils.ads
@@ -213,6 +213,10 @@ package AWS.Utils is
         then Normalize_Lower'Result = Characters.Handling.To_Lower (Name)
         else Normalize_Lower'Result = Name);
 
+   procedure Dump_Binary (Data : Stream_Element_Array);
+   --  Print Data to standard output and if all elements of Data represent
+   --  printable characters then print representing string in the next line.
+
    ---------------
    -- Semaphore --
    ---------------

--- a/src/http2/aws-http2-connection.adb
+++ b/src/http2/aws-http2-connection.adb
@@ -39,10 +39,97 @@ package body AWS.HTTP2.Connection is
      (Current, Increment : Integer) return Boolean
    is
       Max : constant Natural :=
-              Natural (HTTP2.Frame.Window_Update.Size_Increment_Type'Last);
+              Natural (Frame.Window_Update.Size_Increment_Type'Last);
    begin
-      return Current <= Max - Increment;
+      return Increment <= 0 or else Current <= Max - Increment;
    end Flow_Control_Window_Valid;
+
+   --------------------------
+   -- Handle_Control_Frame --
+   --------------------------
+
+   procedure Handle_Control_Frame
+     (Self             : in out Object;
+      Frame            : HTTP2.Frame.Object'Class;
+      Answers          : in out HTTP2.Frame.List.Object;
+      Add_Flow_Control : out Integer;
+      Error            : out HTTP2.Error_Codes)
+   is
+
+      procedure Handle (Frame : HTTP2.Frame.Settings.Object);
+      --  Handle settings frame values
+
+      procedure Handle (Frame : HTTP2.Frame.Window_Update.Object);
+      --  Handle window update frame value
+
+      package S renames HTTP2.Frame.Settings;
+
+      ------------
+      -- Handle --
+      ------------
+
+      procedure Handle (Frame : HTTP2.Frame.Settings.Object) is
+         use type S.Settings_Kind;
+
+         Initial_Window_Size : constant Integer :=
+                                 Self.Initial_Window_Size;
+      begin
+         Self.Set (Frame.Values);
+
+         --  Update the control flow window size of all streams
+
+         for V of Frame.Values loop
+            if V.Id = S.INITIAL_WINDOW_SIZE then
+               Add_Flow_Control := Integer (V.Value) - Initial_Window_Size;
+            end if;
+         end loop;
+      end Handle;
+
+      procedure Handle (Frame : HTTP2.Frame.Window_Update.Object) is
+         Incr : constant Natural := Natural (Frame.Size_Increment);
+      begin
+         if Flow_Control_Window_Valid (Self.Flow_Control_Window, Incr) then
+            Self.Update_Flow_Control_Window (Incr);
+         else
+            Error := HTTP2.C_Flow_Control_Error;
+            return;
+         end if;
+      end Handle;
+
+      use AWS.HTTP2.Frame;
+
+   begin
+      Error            := HTTP2.C_No_Error;
+      Add_Flow_Control := 0;
+
+      if Frame.Kind = K_Ping
+        and then not Frame.Has_Flag (HTTP2.Frame.Ack_Flag)
+      then
+         --  A probing ping frame, respond now with the same
+         --  payload (see RFC-7540 / 6.7).
+
+         declare
+            R_Ping : HTTP2.Frame.Object'Class := Frame;
+         begin
+            R_Ping.Set_Flags (HTTP2.Frame.Ack_Flag);
+            Answers.Prepend (R_Ping);
+         end;
+
+      elsif Frame.Kind = K_Settings
+        and then not Frame.Has_Flag (HTTP2.Frame.Ack_Flag)
+      then
+         Handle (HTTP2.Frame.Settings.Object (Frame));
+         Answers.Prepend (HTTP2.Frame.Settings.Ack);
+
+      elsif Frame.Kind = K_Settings
+        and then Frame.Has_Flag (HTTP2.Frame.Ack_Flag)
+      then
+         Answers.Prepend (HTTP2.Frame.Settings.Ack);
+
+      elsif Frame.Kind = K_Window_Update then
+         Handle (HTTP2.Frame.Window_Update.Object (Frame));
+      end if;
+   end Handle_Control_Frame;
 
    ---------
    -- Set --

--- a/src/http2/aws-http2-connection.ads
+++ b/src/http2/aws-http2-connection.ads
@@ -32,6 +32,7 @@
 with AWS.Config;
 with AWS.Default;
 
+with AWS.HTTP2.Frame.List;
 with AWS.HTTP2.Frame.Settings;
 with AWS.Net;
 
@@ -104,6 +105,15 @@ package AWS.HTTP2.Connection is
    function Flow_Control_Window (Self : Object) return Integer;
 
    function Flow_Receive_Window (Self : Object) return Integer;
+
+   procedure Handle_Control_Frame
+     (Self             : in out Object;
+      Frame            : HTTP2.Frame.Object'Class;
+      Answers          : in out HTTP2.Frame.List.Object;
+      Add_Flow_Control : out Integer;
+      Error            : out HTTP2.Error_Codes)
+     with Pre => Frame.Stream_Id = 0;
+   --  Handle a control frame (Frame id = 0)
 
 private
 

--- a/src/http2/aws-http2-frame-goaway.adb
+++ b/src/http2/aws-http2-frame-goaway.adb
@@ -27,8 +27,6 @@
 --  covered by the  GNU Public License.                                     --
 ------------------------------------------------------------------------------
 
-with Ada.Text_IO;
-
 with AWS.Net.Buffered;
 
 package body AWS.HTTP2.Frame.GoAway is
@@ -62,13 +60,8 @@ package body AWS.HTTP2.Frame.GoAway is
    ------------------
 
    overriding procedure Dump_Payload (Self : Object) is
-      use Ada.Text_IO;
    begin
-      for E of Self.Data.S.all loop
-         Put (Utils.Hex (Natural (E), 2));
-         Put (" ");
-      end loop;
-      New_Line;
+      Utils.Dump_Binary (Self.Data.S.all);
    end Dump_Payload;
 
    ----------

--- a/src/http2/aws-http2-frame.adb
+++ b/src/http2/aws-http2-frame.adb
@@ -134,6 +134,11 @@ package body AWS.HTTP2.Frame is
       --  The frame is invalid, do not try to build the payload, return now
 
       if not H.Header.H.Kind'Valid then
+         if Debug then
+            Put ("INALID ");
+            Utils.Dump_Binary (H.Header.S);
+         end if;
+
          H.Header.H.Kind := K_Invalid;
       end if;
 


### PR DESCRIPTION
Do not need update connection flow control together with stream
flow control. Connection flow control has to be updated separately.
Fixes file dowmload longer than 2G.

TN: S507-051