### PR TITLE
Avoid "attempt to tamper with cursors" exception

### DIFF
--- a/src/core/aws-server-protocol_handler_v2.adb
+++ b/src/core/aws-server-protocol_handler_v2.adb
@@ -961,8 +961,6 @@ begin
                     (LA.Server.Error_Log, Get_Status.all, Message);
                end if;
 
-               S.Exclude (Stream_Id);
-
                HTTP2.Frame.GoAway.Create
                  (Stream_Id => Last_SID, Error => Error).Send (Sock.all);
 

--- a/src/http2/aws-http2-frame.adb
+++ b/src/http2/aws-http2-frame.adb
@@ -88,8 +88,11 @@ package body AWS.HTTP2.Frame is
          Ref_Counter.all := Ref_Counter.all - 1;
 
          if Ref_Counter.all = 0 then
+            --  Call to Release (Self); or Self.Release; does not dispatch.
+            --  Need GNAT bug report.
+
+            Release (Object'Class (Self));
             Utils.Unchecked_Free (Ref_Counter);
-            Release (Self);
          end if;
       end if;
    end Finalize;


### PR DESCRIPTION
* src/core/aws-server-protocol_handler_v2.adb (Go_Away):
Do not remove stream from S stream set.
It is not necessary because there is exit from For_Every_Frame loop and
return from Protocol_Handler_V2 after Go_Away call.
It was
raised PROGRAM_ERROR :
  AWS.HTTP2.Stream.Set.Maps.Tree_Types.Implementation.TC_Check:
  attempt to tamper with cursors
in AWS error logs on h2spec testing on S.Exclude (Stream_Id).

Part of S507-051.