### PR TITLE
Remove HTTP/1 specific output for test.

### DIFF
--- a/regtests/0151_upload2/test-h2.out
+++ b/regtests/0151_upload2/test-h2.out
@@ -1,7 +1,0 @@
-Start main, wait for server to start...
-Server started
-
-Ok, exception received on the server side
-  => ADA.IO_EXCEPTIONS.NAME_ERROR
-  => Cannot create file /this/one/does/not/exists/.file.txt
-=> Cannot create file /this/one/does/not/exists/.file.txt

--- a/regtests/0151_upload2/test.opt
+++ b/regtests/0151_upload2/test.opt
@@ -1,2 +1,1 @@
 vxworks6-6.6 OUT test-vx6.6.out
-client_http2 OUT test-h2.out

--- a/regtests/0151_upload2/test.out
+++ b/regtests/0151_upload2/test.out
@@ -4,4 +4,4 @@ Server started
 Ok, exception received on the server side
   => ADA.IO_EXCEPTIONS.NAME_ERROR
   => Cannot create file /this/one/does/not/exists/.file.txt
-=> Upload request error. raised AWS.NET.SOCKET_ERROR : Receive : Socket closed by peer
+=> Cannot create file /this/one/does/not/exists/.file.txt

--- a/regtests/0193_attachment_headers/test-h2.out
+++ b/regtests/0193_attachment_headers/test-h2.out
@@ -1,0 +1,24 @@
+Start...
+Insert attachment...
+Call Post...
+Post headers:
+:method
+:path
+:scheme
+accept
+accept-encoding
+accept-language
+content-custom-header
+content-length
+content-type
+custom-header
+host
+user-agent
+x-message-seconds
+Attachment headers:
+content-custom-header
+content-disposition
+content-transfer-encoding
+content-type
+custom-header
+x-message-seconds

--- a/regtests/0193_attachment_headers/test.opt
+++ b/regtests/0193_attachment_headers/test.opt
@@ -1,0 +1,1 @@
+client_http2 OUT test-h2.out


### PR DESCRIPTION
The same output is now ok for both HTTP/1 and HTTP/2.

Part of S507-051.
Fixes UB08-007.