### PR TITLE
Fix memory leak with OpenSSL 1.1.1

### DIFF
--- a/config/ssl/aws-net-ssl__dummy.adb
+++ b/config/ssl/aws-net-ssl__dummy.adb
@@ -389,6 +389,14 @@ package body AWS.Net.SSL is
       raise Program_Error with Error_Message;
    end Set_Verify_Callback;
 
+   ----------------------------
+   -- Show_Session_Statistic --
+   ----------------------------
+
+   procedure Show_Session_Statistic
+     (Config : SSL.Config;
+      Report : not null access procedure (Line : String)) is null;
+
    --------------
    -- Shutdown --
    --------------

--- a/config/ssl/aws-net-ssl__gnutls.adb
+++ b/config/ssl/aws-net-ssl__gnutls.adb
@@ -2172,6 +2172,18 @@ package body AWS.Net.SSL is
       Config.Verify_CB := To_Callback (Callback);
    end Set_Verify_Callback;
 
+   ----------------------------
+   -- Show_Session_Statistic --
+   ----------------------------
+
+   procedure Show_Session_Statistic
+     (Config : SSL.Config;
+      Report : not null access procedure (Line : String)) is
+   begin
+      Report ("cache_size" & Config.Sessions.Get_Size'Img);
+      Report ("number    " & Config.Sessions.Length'Img);
+   end Show_Session_Statistic;
+
    --------------
    -- Shutdown --
    --------------

--- a/config/ssl/openssl/wrappers.c
+++ b/config/ssl/openssl/wrappers.c
@@ -108,6 +108,11 @@ unsigned long __aws_OpenSSL_version_num(void)
   return OpenSSL_version_num();
 }
 
+void __aws_OPENSSL_thread_stop(void)
+{
+  OPENSSL_thread_stop();
+}
+
 const char * __aws_OpenSSL_version(int t)
 {
   return OpenSSL_version(t);
@@ -144,6 +149,9 @@ const char * __aws_OpenSSL_version(int t)
 {
   return SSLeay_version(t);
 }
+
+void __aws_OPENSSL_thread_stop(void)
+{}
 
 const SSL_METHOD * __aws_TLS_method(void)
 {

--- a/config/ssl/ssl-thin__openssl.ads
+++ b/config/ssl/ssl-thin__openssl.ads
@@ -768,6 +768,15 @@ package SSL.Thin is
      with Import, Convention => C, External_Name => "__aws_OpenSSL_version";
    --  Returns version information line
 
+   -------------------------------------
+   -- OPENSSL thread related routines --
+   -------------------------------------
+
+   procedure OPENSSL_thread_stop
+     with Import, Convention => C,
+          External_Name => "__aws_OPENSSL_thread_stop";
+   --  Deallocates resources associated with the current thread
+
    -------------------------------
    -- Context control routines  --
    -------------------------------

--- a/regtests/0043_check_mem/check_mem.adb
+++ b/regtests/0043_check_mem/check_mem.adb
@@ -329,11 +329,7 @@ procedure Check_Mem is
       AWS.Net.SSL.Initialize
         (Config               => SSL_Srv,
          Certificate_Filename => Certificate_Name,
-         Key_Filename         => Private_Key_Name,
-         Session_Cache_Size   => 2);
-
-      --  Session_Cache_Size  => 2 - limit session cache to avoid different
-      --  cache container allocation in different execution.
+         Key_Filename         => Private_Key_Name);
 
       AWS.Server.Set_SSL_Config (HTTP, SSL_Srv);
 
@@ -1051,6 +1047,11 @@ begin
         (K rem 3 = 1, Generation_Logging'Access);
 
       Net.SSL.Release (Config => SSL_Clt);
+
+      if K = 1 then
+         Net.SSL.Set_Session_Cache_Size
+           (Net.SSL.Session_Cache_Number (SSL_Srv), SSL_Srv);
+      end if;
    end loop;
 
    Server.Stopped;

--- a/regtests/0118_test_net_log/test.out
+++ b/regtests/0118_test_net_log/test.out
@@ -17,8 +17,8 @@ User-Agent:
 Date:
 Server:
 Connection: close
-Content-Type: text/html
 Content-Length: 16
+Content-Type: text/html
 
 <p>Hello world !
 
@@ -40,7 +40,7 @@ User-Agent:
 Date:
 Server:
 Connection: close
-Content-Type: text/html
 Content-Length: 16
+Content-Type: text/html
 
 <p>Hello world !

--- a/regtests/0144_tlog/tlog_proc.adb
+++ b/regtests/0144_tlog/tlog_proc.adb
@@ -142,6 +142,7 @@ procedure TLog_Proc (Extended_Fields : String) is
       I       : AWK.Count;
       Ext_Log : Boolean;
       Parser  : AWK.Session_Type;
+      H_Error : Boolean; -- To mark header error line
    begin
       AWK.Add_File ("tlog-" & Today & ".log", Parser);
       AWK.Add_File ("tlog_error-" & Today & ".log", Parser);
@@ -153,7 +154,6 @@ procedure TLog_Proc (Extended_Fields : String) is
       Text_IO.Put_Line ("> File : " & Hide_Date (AWK.File));
 
       while not AWK.End_Of_Data loop
-
          if AWK.End_Of_File then
             AWK.Get_Line;
             Text_IO.Put_Line ("> File : " & Hide_Date (AWK.File));
@@ -163,6 +163,8 @@ procedure TLog_Proc (Extended_Fields : String) is
 
          Ext_Log := Integer (AWK.NF)
                     = AWS.Config.Log_Extended_Fields_Length (Config);
+
+         H_Error := False;
 
          if AWK.Field (1) (1) = '#' then
             I := 0;
@@ -196,7 +198,37 @@ procedure TLog_Proc (Extended_Fields : String) is
             end if;
 
             for K in I + 1 .. AWK.Count'Min (9 + I, AWK.NF) loop
-               Text_IO.Put (AWK.Field (K));
+               declare
+                  V  : constant String    := AWK.Field (K);
+                  NE : constant AWK.Count := (if Ext_Log then 0 else 1);
+                  H2 : String renames AWS.HTTP_2;
+               begin
+                  case K + NE is
+                     when 7 =>
+                        H_Error := V = "/header/line/error";
+                        Text_IO.Put (V);
+                     when 8 =>
+                        if not H_Error
+                          and then AWS.Client.HTTP_Default = HTTPv2
+                          and then V'Length >= H2'Length
+                          and then V (V'First .. V'First + H2'Length - 1) = H2
+                        then
+                           --  Mask HTTP/2 to HTTP/1.1 to have the same test
+                           --  output.
+
+                           Text_IO.Put
+                             (V (V'First .. V'First + 4) & "1.1"
+                              & V (V'Last
+                                   .. V'Last - 1 + V'Length - H2'Length));
+                        else
+                           Text_IO.Put (V);
+                        end if;
+
+                     when others =>
+                        Text_IO.Put (V);
+                  end case;
+               end;
+
                Text_IO.Put (" | ");
             end loop;
 

--- a/regtests/0155_user_sock/test.out
+++ b/regtests/0155_user_sock/test.out
@@ -16,8 +16,8 @@ HTTP/1.1 200 OK
 Date: xxx, xx xxx xxxx xx:xx:xx xxx
 Server: AWS (Ada Web Server) vx.y
 Connection: close
-Content-Type: text/html
 Content-Length: 22
+Content-Type: text/html
 
 response from U_Socket
 --

--- a/regtests/0317_hide_id/test.out
+++ b/regtests/0317_hide_id/test.out
@@ -18,9 +18,9 @@ User-Agent: AWS (Ada Web Server) v##.#
 Date:
 Server: justme_server
 Connection: close
+Content-Length: 16
 X-Answer: 1st-First
 Content-Type: text/html
-Content-Length: 16
 
 <p>Hello world !
 @@@ SENT ( 180/ 180 buffer usage) @@@
@@ -44,9 +44,9 @@ User-Agent: justme_client
 Date:
 Server: justme_server
 Connection: close
+Content-Length: 16
 X-Answer: 2nd-Second
 Content-Type: text/html
-Content-Length: 16
 
 <p>Hello world !
 @@@ SENT ( 181/ 181 buffer usage) @@@
@@ -69,9 +69,9 @@ Accept-Language: fr, ru, us
 Date:
 Server: justme_server
 Connection: close
+Content-Length: 16
 X-Answer: 3rd-Third
 Content-Type: text/html
-Content-Length: 16
 
 <p>Hello world !
 @@@ SENT ( 180/ 180 buffer usage) @@@

--- a/src/core/aws-net-ssl.ads
+++ b/src/core/aws-net-ssl.ads
@@ -341,6 +341,12 @@ package AWS.Net.SSL is
 
    overriding function Is_Secure (Socket : Socket_Type) return Boolean;
 
+   procedure Show_Session_Statistic
+     (Config : SSL.Config;
+      Report : not null access procedure (Line : String));
+   --  Show session statistic for Config. Report will be called for each line
+   --  of the statistic.
+
 private
 
    package TSSL renames Standard.SSL.Thin;

--- a/src/core/aws-response.adb
+++ b/src/core/aws-response.adb
@@ -59,6 +59,7 @@ package body AWS.Response is
       else
          Set.Message_Body (Result, Message_Body);
          Set.Content_Type (Result, Content_Type);
+         Set.Content_Length (Result);
       end if;
 
       return Result;
@@ -146,11 +147,12 @@ package body AWS.Response is
    is
       Result : Data;
    begin
-      Set.Status_Code   (Result, Status_Code);
-      Set.Content_Type  (Result, Content_Type);
-      Set.Data_Encoding (Result, Encoding);
-      Set.Message_Body  (Result, Message_Body);
-      Set.Cache_Control (Result, Cache_Control);
+      Set.Status_Code    (Result, Status_Code);
+      Set.Content_Type   (Result, Content_Type);
+      Set.Data_Encoding  (Result, Encoding);
+      Set.Message_Body   (Result, Message_Body);
+      Set.Cache_Control  (Result, Cache_Control);
+      Set.Content_Length (Result);
       return Result;
    end Build;
 
@@ -169,6 +171,7 @@ package body AWS.Response is
       Set.Data_Encoding (Result, Encoding);
       Set.Message_Body  (Result, UString_Message);
       Set.Cache_Control (Result, Cache_Control);
+      Set.Content_Length (Result);
       return Result;
    end Build;
 
@@ -187,6 +190,7 @@ package body AWS.Response is
       Set.Data_Encoding (Result, Encoding);
       Set.Message_Body  (Result, Message_Body);
       Set.Cache_Control (Result, Cache_Control);
+      Set.Content_Length (Result);
       return Result;
    end Build;
 

--- a/src/core/aws-server-http_utils.adb
+++ b/src/core/aws-server-http_utils.adb
@@ -1421,8 +1421,7 @@ package body AWS.Server.HTTP_Utils is
               (LA.Server.Log, LA.Log_Data, "sc-status",
                Messages.Image (Status_Code));
             Log.Set_Field
-              (LA.Server.Log, LA.Log_Data, "sc-bytes",
-               Utils.Image (Integer (Length)));
+              (LA.Server.Log, LA.Log_Data, "sc-bytes", Utils.Image (Length));
 
             Log.Write (LA.Server.Log, LA.Log_Data);
          end;
@@ -2353,7 +2352,10 @@ package body AWS.Server.HTTP_Utils is
          --  then the end of the stream will be determined by closing the
          --  connection. [RFC 1945 - 7.2.2] See the Will_Close local variable.
 
-         if Length /= Resources.Undefined_Length then
+         if Length /= Resources.Undefined_Length
+           and then not Response.Has_Header
+                          (Answer, Messages.Content_Length_Token)
+         then
             Net.Buffered.Put_Line (Sock, Messages.Content_Length (Length));
          end if;
 

--- a/src/http2/aws-http2-message.adb
+++ b/src/http2/aws-http2-message.adb
@@ -173,7 +173,7 @@ package body AWS.HTTP2.Message is
                Set_Body;
 
                if Size /= Resources.Undefined_Length then
-                  O.Headers.Add
+                  O.Headers.Update
                     (Messages.Content_Length_Token, Utils.Image (Size));
                end if;
             end if;
@@ -286,7 +286,7 @@ package body AWS.HTTP2.Message is
                               & Utils.Image (Natural (Last))
                               & "/" & Utils.Image (Natural (Size)));
 
-                           O.Headers.Add
+                           O.Headers.Update
                              (Messages.Content_Length_Token,
                               Utils.Image (R_Length));
 
@@ -300,7 +300,7 @@ package body AWS.HTTP2.Message is
                   end;
 
                elsif Size /= Resources.Undefined_Length then
-                  O.Headers.Add
+                  O.Headers.Update
                     (Messages.Content_Length_Token, Utils.Image (Size));
                end if;
             end;


### PR DESCRIPTION
Memory leak was because of GNAT task control block recreated on OpenSSL
thread specific resources automatic deallocation.