### PR TITLE
Add parenthesis into the set of characters that need to be encoded.

### DIFF
--- a/src/core/aws-url.ads
+++ b/src/core/aws-url.ads
@@ -236,7 +236,7 @@ private
                                               High => Character'Val (31)));
    Default_Encoding_Set : constant Strings.Maps.Character_Set :=
                             Parameters_Encoding_Set
-                            or Strings.Maps.To_Set (";/:$,""{}|\^[]`'");
+                            or Strings.Maps.To_Set (";/:$,""{}|\^[]`'()");
 
    function Decode (Str : String; In_Params : Boolean) return String;
    --  Decode URL Str. In_Params is set to True when decoding the


### PR DESCRIPTION
This is needed as per RFC-3986 Section 2.2.

Fixes UB18-057.