### PR TITLE
Force clean without close the socket when possible

### DIFF
--- a/src/core/aws-net-acceptors.ads
+++ b/src/core/aws-net-acceptors.ads
@@ -184,9 +184,10 @@ private
 
       function Size return Natural;
 
-      procedure Clear;
+      procedure Shutdown;
 
    private
+      Open   : Boolean := True;
       Buffer : Socket_Data_Lists.List;
    end Socket_Box;
 

--- a/src/core/aws-server-protocol_handler.adb
+++ b/src/core/aws-server-protocol_handler.adb
@@ -73,9 +73,6 @@ procedure Protocol_Handler (LA : in out Line_Attribute_Record) is
    Extended_Log : constant Boolean :=
                     CNF.Log_Extended_Fields_Length (LA.Server.Properties) > 0;
 
-   Multislots   : constant Boolean :=
-                    CNF.Max_Connection (LA.Server.Properties) > 1;
-
    Request : AWS.Status.Data renames LA.Stat.all;
 
 begin
@@ -135,7 +132,7 @@ begin
             --  First arrived. We do not need to wait for fast comming next
             --  keep alive request.
 
-            Sock_Ptr := LA.Server.Slots.Get (Index => LA.Line).Sock;
+            Sock_Ptr := LA.Server.Slots.Get_Socket (Index => LA.Line);
             pragma Assert (Sock_Ptr /= null);
 
          else
@@ -203,13 +200,6 @@ begin
 
             LA.Server.Slots.Increment_Slot_Activity_Counter
               (LA.Line, Free_Slots);
-
-            --  If there is no more slot available and we have many
-            --  of them, try to abort one of them.
-
-            if Multislots and then Free_Slots = 0 then
-               Force_Clean (LA.Server.all);
-            end if;
 
             if Extended_Log then
                AWS.Log.Set_Field

--- a/src/core/aws-server-protocol_handler_v2.adb
+++ b/src/core/aws-server-protocol_handler_v2.adb
@@ -117,15 +117,12 @@ is
                         CNF.Log_Extended_Fields_Length
                           (LA.Server.Properties) > 0;
 
-   Multislots       : constant Boolean :=
-                        CNF.Max_Connection (LA.Server.Properties) > 1;
-
    Keep_Alive_Close_Limit : constant Natural :=
                               CNF.Keep_Alive_Close_Limit
                                 (LA.Server.Properties);
 
    Sock             : constant Socket_Access :=
-                        LA.Server.Slots.Get (Index => LA.Line).Sock;
+                        LA.Server.Slots.Get_Socket (Index => LA.Line);
 
    Free_Slots : Natural;
 
@@ -471,10 +468,6 @@ is
       --  of them, try to abort one of them.
 
       LA.Server.Slots.Increment_Slot_Activity_Counter (LA.Line, Free_Slots);
-
-      if Multislots and then Free_Slots = 0 then
-         Force_Clean (LA.Server.all);
-      end if;
 
       if Extended_Log then
          AWS.Log.Set_Field


### PR DESCRIPTION
We can release task and do not close the socket on hard loaded server at
time when task waiting for next client request.
Minor optimisation.