### PR TITLE
Fix compilation error in debug mode due to new GNAT check.

### DIFF
--- a/src/core/aws-client-http_utils.ads
+++ b/src/core/aws-client-http_utils.ads
@@ -29,7 +29,6 @@
 
 pragma Ada_2012;
 
-with AWS.Client;
 with AWS.Config;
 with AWS.HTTP2.Frame.Settings;
 with AWS.Response;

--- a/src/core/aws-dispatchers-callback.ads
+++ b/src/core/aws-dispatchers-callback.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2013, AdaCore                     --
+--                     Copyright (C) 2000-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -31,7 +31,6 @@ pragma Ada_2012;
 
 --  Dispatch on a Callback procedure
 
-with AWS.Dispatchers;
 with AWS.Response;
 with AWS.Status;
 

--- a/src/core/aws-net-acceptors.ads
+++ b/src/core/aws-net-acceptors.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2005-2017, AdaCore                     --
+--                     Copyright (C) 2005-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -33,7 +33,6 @@ pragma Ada_2012;
 
 with Ada.Containers.Doubly_Linked_Lists;
 
-with AWS.Net;
 with AWS.Net.Generic_Sets;
 with AWS.Utils;
 

--- a/src/core/aws-net-websocket-registry.adb
+++ b/src/core/aws-net-websocket-registry.adb
@@ -46,7 +46,6 @@ with AWS.Net.Generic_Sets;
 with AWS.Net.Memory;
 with AWS.Net.Poll_Events;
 with AWS.Net.Std;
-with AWS.Net.WebSocket;
 with AWS.Utils;
 
 package body AWS.Net.WebSocket.Registry is

--- a/src/soap/soap-message-response-error.ads
+++ b/src/soap/soap-message-response-error.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                              Ada Web Server                              --
 --                                                                          --
---                     Copyright (C) 2000-2015, AdaCore                     --
+--                     Copyright (C) 2000-2021, AdaCore                     --
 --                                                                          --
 --  This library is free software;  you can redistribute it and/or modify   --
 --  it under terms of the  GNU General Public License  as published by the  --
@@ -28,7 +28,6 @@
 ------------------------------------------------------------------------------
 
 with SOAP.Message.Payload;
-with SOAP.Message.Response;
 
 package SOAP.Message.Response.Error is
 


### PR DESCRIPTION
A with clause of an ancestor is superfluous and GNAT now detect
this and issue a warning:

   warning: unnecessary with of ancestor [-gnatwr]