### PR TITLE
Fix possible Constraint_Error on integer overflow

### DIFF
--- a/src/extended/aws-net-log-callbacks.adb
+++ b/src/extended/aws-net-log-callbacks.adb
@@ -217,8 +217,8 @@ package body AWS.Net.Log.Callbacks is
 
       Text_IO.Put (File, "socket " & Utils.Image (Get_FD (Socket)));
       Text_IO.Put_Line
-        (File, " (" & Utils.Image (Natural (Last))
-         & "/" & Utils.Image (Natural (Data'Last)) & ')');
+        (File,
+         " (" & Utils.Image (Last) & "/" & Utils.Image (Data'Last) & ')');
    end Put_Header;
 
    -------------

--- a/src/http2/aws-http2-message.adb
+++ b/src/http2/aws-http2-message.adb
@@ -282,9 +282,8 @@ package body AWS.HTTP2.Message is
                            O.Headers.Add
                              (Messages.Content_Range_Token,
                               "bytes "
-                              & Utils.Image (Natural (First)) & "-"
-                              & Utils.Image (Natural (Last))
-                              & "/" & Utils.Image (Natural (Size)));
+                              & Utils.Image (First) & "-" & Utils.Image (Last)
+                              & "/" & Utils.Image (Size));
 
                            O.Headers.Update
                              (Messages.Content_Length_Token,


### PR DESCRIPTION
Do not convert Stream_Element_Offset to Integer on call to AWS.Utils.Image,
use appropriate AWS.Utils.Image instead. Fixes possible similar issue as
described in #316 PR.