### PR TITLE
XFAIL a number of SSL-only testscases

### DIFF
--- a/regtests/0012_sock2_sec/test.opt
+++ b/regtests/0012_sock2_sec/test.opt
@@ -1,1 +1,2 @@
-!ssl DEAD
+ssl REQUIRED
+ALL  XFAIL investigated under VC15-012

--- a/regtests/0033_afile_sec/test.opt
+++ b/regtests/0033_afile_sec/test.opt
@@ -1,1 +1,3 @@
-!ssl DEAD
+ssl REQUIRED
+windows-2012  XFAIL investigated under VC15-012
+windows-2022  XFAIL investigated under VC15-012

--- a/regtests/0035_append_sec/test.opt
+++ b/regtests/0035_append_sec/test.opt
@@ -1,1 +1,3 @@
-!ssl DEAD
+ssl  REQUIRED
+windows-2012  XFAIL investigated under VC15-012
+windows-2022  XFAIL investigated under VC15-012

--- a/regtests/0043_check_mem/test.opt
+++ b/regtests/0043_check_mem/test.opt
@@ -1,3 +1,4 @@
-!ssl DEAD
-!xmlada DEAD
+ssl    REQUIRED
+xmlada REQUIRED
 darwin DEAD "no gnatmem"
+windows-2022  XFAIL investigated under VC15-012

--- a/regtests/0226_client_cert/test.opt
+++ b/regtests/0226_client_cert/test.opt
@@ -1,3 +1,4 @@
-!ssl DEAD
+ssl REQUIRED
 -- gnutls: client sends only certs which match the server's CA (see README)
 gnutls OUT test-gnutls.out
+ALL    XFAIL investigated under VC15-012

--- a/regtests/0231_cert_status/test.opt
+++ b/regtests/0231_cert_status/test.opt
@@ -1,2 +1,7 @@
-!ssl DEAD
+ssl REQUIRED
 gnutls OUT test-gnutls.out
+--  The test actually only fails on SuSE 12 and SuSE 15, but as far
+--  as I can tell, we do not produce a SuSE 15 discriminant :-(.
+--  XFAIL the test on all Linux platforms for now as a workaround.
+linux         XFAIL investigated under VC15-012
+windows-2022  XFAIL investigated under VC15-012

--- a/regtests/0235_crl_check/test.opt
+++ b/regtests/0235_crl_check/test.opt
@@ -1,3 +1,4 @@
-!ssl DEAD
+ssl REQUIRED
 gnutls OUT test-gnutls.out
 NT DEAD test requires UNIX shell
+linux XFAIL investigated under VC15-012

--- a/regtests/0236_snb_send/test.opt
+++ b/regtests/0236_snb_send/test.opt
@@ -1,1 +1,2 @@
-!ssl DEAD
+ssl REQUIRED
+windows-2022  XFAIL investigated under VC15-012

--- a/regtests/0243_sshort/test.opt
+++ b/regtests/0243_sshort/test.opt
@@ -1,1 +1,3 @@
-!ssl DEAD
+ssl REQUIRED
+--  Fails on all versions of Windows except Windows 2022
+windows,!windows-2022  XFAIL investigated under VC15-012

--- a/regtests/0246_ctr_chain/test.opt
+++ b/regtests/0246_ctr_chain/test.opt
@@ -1,1 +1,2 @@
-!ssl DEAD
+ssl REQUIRED
+ALL  XFAIL  investigated under VC15-012


### PR DESCRIPTION
We noticed when running the testsuite with SSL activated that a number of testcases were failing. We will investigate those failures under VC15-012, and in the meantime, to acknowledge that those failures do not look critical, this commit is XFAIL-ing those tests.

In doing so, this commit adjusts a number of "!ssl DEAD" commands in favor of using the "ssl REQUIRED" command instead, which has the advantage of not being "cancellable" by other commands. Without this, the order of the entries in the test.opt can be treacherous.

TN: VC15-012