### PR TITLE
Add some missing test.opt to kill tests if LAL not set.

### DIFF
--- a/regtests/0337_subtype_array_index/test.opt
+++ b/regtests/0337_subtype_array_index/test.opt
@@ -1,0 +1,2 @@
+!lal DEAD
+!xmlada DEAD

--- a/regtests/0338_access_type/test.opt
+++ b/regtests/0338_access_type/test.opt
@@ -1,0 +1,1 @@
+!lal DEAD

--- a/regtests/0339_wsdl_fixed_point/test.opt
+++ b/regtests/0339_wsdl_fixed_point/test.opt
@@ -1,0 +1,2 @@
+!lal DEAD
+!xmlada DEAD

--- a/regtests/0340_array_named_index/test.opt
+++ b/regtests/0340_array_named_index/test.opt
@@ -1,0 +1,1 @@
+!lal DEAD


### PR DESCRIPTION
Tests using ada2wsdl must have LAL discriminant and tests using wsdl2aws must have XMLADA discriminant.

Continued work for W124-025.