### PR TITLE
Make 'make setup' macOS-compatible.

### DIFF
--- a/makefile.conf
+++ b/makefile.conf
@@ -147,13 +147,13 @@ PROCESSORS	= 0
 # HTTP2 server activated
 #
 SERVER_HTTP2 = $(strip \
-                 $(shell sed -ns 's/HTTP2_Activated.*:= *\([a-zA-Z]*\);/\1/p' \
+                 $(shell sed -n 's/HTTP2_Activated.*:= *\([a-zA-Z]*\);/\1/p' \
                      src/core/aws-default.ads | tr '[:upper:]' '[:lower:]'))
 
 ##############################################################################
 # HTTP2 client activated
 #
-C_HTTP2 = $(shell sed -ns 's/HTTP_Default.* renames *\([a-zA-Z1-9]*\);/\1/p' \
+C_HTTP2 = $(shell sed -n 's/HTTP_Default.* renames *\([a-zA-Z1-9]*\);/\1/p' \
                      src/core/aws-client.ads)
 
 ifeq ($(strip $(C_HTTP2)),HTTPv1)


### PR DESCRIPTION
'makefile.conf' uses the sed switch '-s', which is not available on macOS; macOS sed is derived from BSD sed, and (according to https://man.freebsd.org/cgi/man.cgi?sed(1)) FreeBSD sed 13.0 doesn't support -s either.

Since the GNU sed -s (--separate) only applies if there are multiple input files, and in each case here there's only one input file, the -s can be removed without penalty.

It would be great if this change could be fed though to the alire version (that’d be v23.0.1, I suppose).