### PR TITLE
fix: memory leak in SMTP server Get_Message function

### DIFF
--- a/src/extended/aws-smtp-server.adb
+++ b/src/extended/aws-smtp-server.adb
@@ -220,7 +220,13 @@ package body AWS.SMTP.Server is
       Messages.Set.Set_Body (Message, To_String (Message_Body));
       Messages.Set.Headers (Message, Headers);
 
+      Net.Free (S);
       return Message;
+
+   exception
+      when others =>
+         Net.Free (S);
+         raise;
    end Get_Message;
 
    --------------


### PR DESCRIPTION
Found a small memory leak in the SMTP server: `Get_Message` creates a socket copy but forgets to free it. The actual socket is fine (it's ref-counted), just the wrapper that leaks.

Added the missing `Net.Free` call + exception handler to clean up properly. Nothing fancy, just following the same cleanup pattern used elsewhere in AWS.