### PR TITLE
Disconnect wsdl2aws-generator-name.adb from the build

### DIFF
--- a/tools/tools.gpr
+++ b/tools/tools.gpr
@@ -42,7 +42,6 @@ project Tools is
                for Locally_Removed_Files use Project'Locally_Removed_Files &
                  ("wsdl2aws.ads", "wsdl2aws-generator.adb",
                   "wsdl2aws-generator.ads",  "wsdl2aws-generator-cb.adb",
-                  "wsdl2aws-generator-name_set.adb",
                   "wsdl2aws-generator-skel.adb", "wsdl2aws-generator-stub.adb",
                   "wsdl2aws-main.adb", "wsdl2aws-wsdl-parameters.adb",
                   "wsdl2aws-wsdl-parameters.ads", "wsdl2aws-wsdl-parser.adb",


### PR DESCRIPTION
The file got removed in d0b8dbdfe31f141383b15143fca834eea8412cb7
but it is still referenced in tools/tools.gpr

tools.gpr:57:53: unknown file "wsdl2aws-generator-name_set.adb"
gprbuild: "tools/tools.gpr" processing failed
gmake: *** [Makefile:144: build-tools-native] Error 5